### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,7 @@
 name: "Build Kotbusta Docker"
+permissions:
+  contents: read
+  packages: write
 
 on:
   - push


### PR DESCRIPTION
Potential fix for [https://github.com/Heapy/kotbusta/security/code-scanning/5](https://github.com/Heapy/kotbusta/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set this at the workflow level (top-level, just after the `name` and before `on`), so it applies to all jobs unless overridden. For this workflow, the minimal required permissions are likely `contents: read` (for checking out code) and `packages: write` (for pushing Docker images to GHCR). If the workflow does not need to write to the repository or manage issues/pull requests, do not grant those permissions. The change should be made at the top of `.github/workflows/build.yml`, after the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
