### PR TITLE
[codex] Handle duplicate INPX book IDs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+kotlin.daemon.jvmargs=-Xmx2g

--- a/src/main/kotlin/io/heapy/kotbusta/parser/InpxParser.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/parser/InpxParser.kt
@@ -81,6 +81,7 @@ class InpxParser(
             ZipFile(inpxFilePath.toString()).use { zipFile ->
                 val entries = zipFile.entries().asSequence()
                     .filter { it.name.endsWith(".inp") }
+                    .sortedBy { it.name }
                     .toList()
 
                 stats.addMessage("Found ${entries.size} .inp files to process")
@@ -93,6 +94,7 @@ class InpxParser(
                         .useLines { lines ->
                             lines.mapNotNull { line -> parseBookLine(line, archiveName, stats) }.toList()
                         }
+                        .deduplicateByBookId(stats)
 
                     if (books.isNotEmpty()) {
                         transactionProvider.transaction(READ_WRITE) {
@@ -205,31 +207,159 @@ class InpxParser(
         genreIds: MutableMap<String, Int>,
         createdAt: Instant,
     ) = useTx { dsl ->
+        val canonicalBooks = filterCanonicalBooks(dsl, staging, books)
+        if (canonicalBooks.isEmpty()) return@useTx
+
         resolveNames(
             dsl = dsl,
             table = staging.authors,
             nameColumn = "FULL_NAME",
-            names = books.flatMapTo(HashSet(), ParsedBook::authors),
+            names = canonicalBooks.flatMapTo(HashSet(), ParsedBook::authors),
             cache = authorIds,
         )
         resolveNames(
             dsl = dsl,
             table = staging.series,
             nameColumn = "NAME",
-            names = books.mapNotNullTo(HashSet(), ParsedBook::series),
+            names = canonicalBooks.mapNotNullTo(HashSet(), ParsedBook::series),
             cache = seriesIds,
         )
         resolveNames(
             dsl = dsl,
             table = staging.genres,
             nameColumn = "NAME",
-            names = books.flatMapTo(HashSet(), ParsedBook::genres),
+            names = canonicalBooks.flatMapTo(HashSet(), ParsedBook::genres),
             cache = genreIds,
         )
 
-        insertBooks(dsl, staging, books, seriesIds, createdAt)
-        insertBookAuthors(dsl, staging, books, authorIds)
-        insertBookGenres(dsl, staging, books, genreIds)
+        replaceExistingStagedBooks(dsl, staging, canonicalBooks.mapTo(HashSet(), ParsedBook::bookId))
+        insertBooks(dsl, staging, canonicalBooks, seriesIds, createdAt)
+        insertBookAuthors(dsl, staging, canonicalBooks, authorIds)
+        insertBookGenres(dsl, staging, canonicalBooks, genreIds)
+    }
+
+    private fun List<ParsedBook>.deduplicateByBookId(stats: ImportStats): List<ParsedBook> {
+        if (size < 2) return this
+
+        val booksById = LinkedHashMap<Int, ParsedBook>(size)
+        var duplicates = 0
+        for (book in this) {
+            if (booksById.put(book.bookId, book) != null) {
+                duplicates += 1
+            }
+        }
+
+        if (duplicates > 0) {
+            stats.addMessage(
+                "Found $duplicates duplicate book record(s) in one INP file; keeping the last record for each ID",
+            )
+        }
+
+        return booksById.values.toList()
+    }
+
+    private fun filterCanonicalBooks(
+        dsl: DSLContext,
+        staging: StagingTables,
+        books: List<ParsedBook>,
+    ): List<ParsedBook> {
+        val existingArchivePaths = selectExistingArchivePaths(
+            dsl = dsl,
+            staging = staging,
+            bookIds = books.mapTo(HashSet(), ParsedBook::bookId),
+        )
+
+        return books.filter { book ->
+            val existingArchivePath = existingArchivePaths[book.bookId]
+                ?: return@filter true
+
+            shouldReplaceStagedBook(
+                bookId = book.bookId,
+                existingArchivePath = existingArchivePath,
+                incomingArchivePath = book.archivePath,
+            )
+        }
+    }
+
+    private fun shouldReplaceStagedBook(
+        bookId: Int,
+        existingArchivePath: String,
+        incomingArchivePath: String,
+    ): Boolean {
+        val existingContainsBook = archiveContainsBook(existingArchivePath, bookId)
+        val incomingContainsBook = archiveContainsBook(incomingArchivePath, bookId)
+
+        return when {
+            incomingContainsBook && !existingContainsBook -> true
+            existingContainsBook && !incomingContainsBook -> false
+            else -> true
+        }
+    }
+
+    private fun archiveContainsBook(
+        archivePath: String,
+        bookId: Int,
+    ): Boolean {
+        val range = ARCHIVE_RANGE_REGEX.matchEntire(archivePath)
+            ?.let { match ->
+                val start = match.groupValues[1].toIntOrNull()
+                val end = match.groupValues[2].toIntOrNull()
+                if (start != null && end != null && start <= end) {
+                    start..end
+                } else {
+                    null
+                }
+            }
+
+        return range?.contains(bookId) == true
+    }
+
+    private fun selectExistingArchivePaths(
+        dsl: DSLContext,
+        staging: StagingTables,
+        bookIds: Set<Int>,
+    ): Map<Int, String> {
+        if (bookIds.isEmpty()) return emptyMap()
+
+        return buildMap {
+            bookIds.chunked(CHUNK_SIZE).forEach { chunk ->
+                val placeholders = chunk.joinToString(", ") { "?" }
+                dsl.resultQuery(
+                    "SELECT ID, ARCHIVE_PATH FROM ${staging.books} WHERE ID IN ($placeholders)",
+                    *chunk.toTypedArray(),
+                ).fetch().forEach { record ->
+                    put(
+                        record.get("ID", Int::class.java),
+                        record.get("ARCHIVE_PATH", String::class.java),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun replaceExistingStagedBooks(
+        dsl: DSLContext,
+        staging: StagingTables,
+        bookIds: Set<Int>,
+    ) {
+        deleteRowsByBookIds(dsl, staging.bookAuthors, "BOOK_ID", bookIds)
+        deleteRowsByBookIds(dsl, staging.bookGenres, "BOOK_ID", bookIds)
+        deleteRowsByBookIds(dsl, staging.books, "ID", bookIds)
+    }
+
+    private fun deleteRowsByBookIds(
+        dsl: DSLContext,
+        table: String,
+        idColumn: String,
+        bookIds: Set<Int>,
+    ) {
+        bookIds.chunked(CHUNK_SIZE).forEach { chunk ->
+            val placeholders = chunk.joinToString(", ") { "?" }
+            dsl.query(
+                "DELETE FROM $table WHERE ${quoteIdentifier(idColumn)} IN ($placeholders)",
+                *chunk.toTypedArray(),
+            ).execute()
+        }
     }
 
     private fun resolveNames(
@@ -322,7 +452,7 @@ class InpxParser(
         authorIds: Map<String, Int>,
     ) {
         val pairs = books.flatMap { book ->
-            book.authors.map { author -> book.bookId to authorIds.getValue(author) }
+            book.authors.distinct().map { author -> book.bookId to authorIds.getValue(author) }
         }
         pairs.chunked(CHUNK_SIZE).forEach { chunk ->
             dsl.batch(
@@ -344,7 +474,7 @@ class InpxParser(
         genreIds: Map<String, Int>,
     ) {
         val pairs = books.flatMap { book ->
-            book.genres.map { genre -> book.bookId to genreIds.getValue(genre) }
+            book.genres.distinct().map { genre -> book.bookId to genreIds.getValue(genre) }
         }
         pairs.chunked(CHUNK_SIZE).forEach { chunk ->
             dsl.batch(
@@ -545,5 +675,6 @@ class InpxParser(
 
     private companion object : Logger() {
         private const val CHUNK_SIZE = 1000
+        private val ARCHIVE_RANGE_REGEX = Regex(""".*?(\d+)-(\d+)$""")
     }
 }

--- a/src/test/kotlin/io/heapy/kotbusta/parser/InpxParserTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/parser/InpxParserTest.kt
@@ -5,8 +5,12 @@ import io.heapy.kotbusta.database.TransactionProvider
 import io.heapy.kotbusta.database.TransactionType.READ_ONLY
 import io.heapy.kotbusta.database.TransactionType.READ_WRITE
 import io.heapy.kotbusta.database.useTx
+import io.heapy.kotbusta.jooq.tables.references.AUTHORS
+import io.heapy.kotbusta.jooq.tables.references.BOOK_AUTHORS
+import io.heapy.kotbusta.jooq.tables.references.BOOK_GENRES
 import io.heapy.kotbusta.jooq.tables.references.BOOKS
 import io.heapy.kotbusta.jooq.tables.references.BOOK_ENRICHMENT
+import io.heapy.kotbusta.jooq.tables.references.GENRES
 import io.heapy.kotbusta.model.ImportStats
 import io.heapy.kotbusta.test.DatabaseExtension
 import kotlinx.coroutines.runBlocking
@@ -67,6 +71,44 @@ class InpxParserTest {
     }
 
     @Test
+    fun `duplicate book ids prefer archive range metadata across inp files`(
+        applicationModule: ApplicationModule,
+    ) = runBlocking {
+        val tx = applicationModule.transactionProvider.value
+        val parser = applicationModule.inpxParser.value
+        val booksDir = Files.createTempDirectory("inpx-test-")
+
+        writeInpxEntries(
+            booksDir,
+            listOf(
+                "f.fb2-8990-8999.inp" to listOf(
+                    book(9001, "Out of range first", author = "First,Author", genre = "first"),
+                ),
+                "f.fb2-9001-9003.inp" to listOf(
+                    book(9001, "In range later", author = "Later,Author", genre = "later"),
+                    book(9002, "Draft", author = "Draft,Author", genre = "draft"),
+                    book(9002, "Beta"),
+                    book(9003, "In range first", author = "Canonical,Author", genre = "canonical"),
+                ),
+                "f.fb2-9004-9005.inp" to listOf(
+                    book(9003, "Out of range later", author = "Wrong,Author", genre = "wrong"),
+                ),
+            ),
+        )
+        parser.parseAndImport(booksDir, ImportStats())
+
+        assertEquals(listOf("In range later", "Beta", "In range first"), syntheticTitles(tx))
+        assertEquals("f.fb2-9001-9003", archivePathForBook(tx, 9001))
+        assertEquals("f.fb2-9001-9003", archivePathForBook(tx, 9003))
+        assertEquals(listOf("Later Author"), authorsForBook(tx, 9001))
+        assertEquals(listOf("later"), genresForBook(tx, 9001))
+        assertEquals(listOf("Canonical Author"), authorsForBook(tx, 9003))
+        assertEquals(listOf("canonical"), genresForBook(tx, 9003))
+        assertEquals(3, countSynthetic(tx))
+        assertEquals(0, stagingTableCount(tx))
+    }
+
+    @Test
     fun `failed staging load leaves live catalog unchanged`(
         applicationModule: ApplicationModule,
     ) = runBlocking {
@@ -78,7 +120,8 @@ class InpxParserTest {
         parser.parseAndImport(booksDir, ImportStats())
         val before = syntheticTitles(tx)
 
-        writeInpx(booksDir, listOf(book(9001, "Duplicate A"), book(9001, "Duplicate B")))
+        Files.writeString(booksDir.resolve("flibusta_fb2_local.inpx"), "not a zip")
+
         assertThrows(Exception::class.java) {
             runBlocking {
                 parser.parseAndImport(booksDir, ImportStats())
@@ -97,31 +140,47 @@ class InpxParserTest {
         val deleted: Boolean = false,
     )
 
-    private fun book(id: Int, title: String) = InpBook(id = id, title = title)
+    private fun book(
+        id: Int,
+        title: String,
+        author: String = "Author,Test",
+        genre: String = "fiction",
+    ) = InpBook(
+        id = id,
+        title = title,
+        author = author,
+        genre = genre,
+    )
 
     private fun writeInpx(dir: Path, books: List<InpBook>) {
+        writeInpxEntries(dir, listOf("books.inp" to books))
+    }
+
+    private fun writeInpxEntries(dir: Path, entries: List<Pair<String, List<InpBook>>>) {
         val sep = ''
-        val lines = books.joinToString("\n") { b ->
-            listOf(
-                b.author,
-                b.genre,
-                b.title,
-                "",
-                "",
-                b.id.toString(),
-                "1024",
-                b.id.toString(),
-                if (b.deleted) "1" else "0",
-                "fb2",
-                "2024-01-01",
-                "ru",
-            ).joinToString(sep.toString())
-        }
         val inpxFile = dir.resolve("flibusta_fb2_local.inpx").toFile()
         ZipOutputStream(inpxFile.outputStream()).use { zip ->
-            zip.putNextEntry(ZipEntry("books.inp"))
-            zip.write(lines.toByteArray(Charsets.UTF_8))
-            zip.closeEntry()
+            entries.forEach { (entryName, books) ->
+                val lines = books.joinToString("\n") { b ->
+                    listOf(
+                        b.author,
+                        b.genre,
+                        b.title,
+                        "",
+                        "",
+                        b.id.toString(),
+                        "1024",
+                        b.id.toString(),
+                        if (b.deleted) "1" else "0",
+                        "fb2",
+                        "2024-01-01",
+                        "ru",
+                    ).joinToString(sep.toString())
+                }
+                zip.putNextEntry(ZipEntry(entryName))
+                zip.write(lines.toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+            }
         }
     }
 
@@ -154,6 +213,42 @@ class InpxParserTest {
                     .from(BOOKS)
                     .where(BOOKS.ID.eq(bookId))
                     .fetchOne(0, Int::class.java) ?: 0) > 0
+            }
+        }
+
+    private suspend fun archivePathForBook(tx: TransactionProvider, bookId: Int): String? =
+        tx.transaction(READ_ONLY) {
+            useTx { dsl ->
+                dsl.select(BOOKS.ARCHIVE_PATH)
+                    .from(BOOKS)
+                    .where(BOOKS.ID.eq(bookId))
+                    .fetchOne(BOOKS.ARCHIVE_PATH)
+            }
+        }
+
+    private suspend fun authorsForBook(tx: TransactionProvider, bookId: Int): List<String> =
+        tx.transaction(READ_ONLY) {
+            useTx { dsl ->
+                dsl.select(AUTHORS.FULL_NAME)
+                    .from(AUTHORS)
+                    .join(BOOK_AUTHORS).on(AUTHORS.ID.eq(BOOK_AUTHORS.AUTHOR_ID))
+                    .where(BOOK_AUTHORS.BOOK_ID.eq(bookId))
+                    .orderBy(AUTHORS.FULL_NAME)
+                    .fetch(AUTHORS.FULL_NAME)
+                    .filterNotNull()
+            }
+        }
+
+    private suspend fun genresForBook(tx: TransactionProvider, bookId: Int): List<String> =
+        tx.transaction(READ_ONLY) {
+            useTx { dsl ->
+                dsl.select(GENRES.NAME)
+                    .from(GENRES)
+                    .join(BOOK_GENRES).on(GENRES.ID.eq(BOOK_GENRES.GENRE_ID))
+                    .where(BOOK_GENRES.BOOK_ID.eq(bookId))
+                    .orderBy(GENRES.NAME)
+                    .fetch(GENRES.NAME)
+                    .filterNotNull()
             }
         }
 


### PR DESCRIPTION
## Summary
- Make INPX import deterministic by processing `.inp` files in name order.
- Deduplicate repeated book IDs within each `.inp`, keeping the last record.
- Resolve duplicate book IDs across `.inp` files by preferring the archive whose filename range contains the book ID, with "later wins" only as a fallback when the range cannot decide.
- Replace stale staged author/genre links when the canonical book record changes.
- Add parser tests covering duplicate IDs, archive-range preference in both boundary directions, and staging cleanup behavior.

## Root Cause
Real Flibusta INPX snapshots can contain duplicate active records for the same book ID at archive boundaries. The duplicate records in the tested snapshot were byte-identical copies in adjacent ZIP archives, while the import staging table uses `ID` as a primary key. The second insert previously failed with `SQLITE_CONSTRAINT_PRIMARYKEY` before the live catalog swap.

## Validation
- `./gradlew :test --tests io.heapy.kotbusta.parser.InpxParserTest`
- Local smoke import against `/Volumes/torrents/books/fb2.Flibusta.Net`: 208 `.inp` files, 562,422 active records parsed, 562,365 final DB books, 0 parse errors, 0 leftover staging tables.
- The local smoke import confirmed canonical archive selection for both boundary directions: `203583 -> f.fb2-203581-214697` and `734707 -> f.fb2-729586-734723`.
