### PR TITLE
[codex] Refresh static UI

### DIFF
--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -143,18 +143,8 @@ function App() {
   };
 
   if (loading) {
-    return h('div', {
-      style: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        height: '100vh',
-        background: '#ecf0f1'
-      }
-    },
-      h('div', { style: { textAlign: 'center' } },
-        h('h2', null, 'Loading...')
-      )
+    return h('div', { className: 'auth-page' },
+      h('div', { className: 'loading-state' }, 'Loading...')
     );
   }
 
@@ -168,7 +158,7 @@ function App() {
     return h(LoginPage);
   }
 
-  return h('div', { style: { minHeight: '100vh', background: '#ecf0f1' } },
+  return h('div', { className: 'app-shell' },
     h(Header, {
       user: user,
       onNavigate: handleNavigate,

--- a/src/main/resources/static/js/components/AdminPanel.js
+++ b/src/main/resources/static/js/components/AdminPanel.js
@@ -2,6 +2,13 @@ import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { api } from '../utils/api.js';
 
+function statusClass(status) {
+  if (status === 'COMPLETED') return 'status-badge success';
+  if (status === 'FAILED') return 'status-badge danger';
+  if (status === 'RUNNING') return 'status-badge warning';
+  return 'status-badge';
+}
+
 export function AdminPanel() {
   const [jobStatus, setJobStatus] = useState(null);
   const [pendingUsers, setPendingUsers] = useState([]);
@@ -10,7 +17,7 @@ export function AdminPanel() {
   useEffect(() => {
     loadData();
 
-    // Always poll for job status every 2 seconds while on this page
+    // Always poll for job status every 2 seconds while on this page.
     const interval = setInterval(() => {
       loadJobStatus();
     }, 2000);
@@ -72,202 +79,115 @@ export function AdminPanel() {
   };
 
   if (loading) {
-    return h('div', { style: { padding: '2rem', textAlign: 'center' } }, 'Loading...');
+    return h('main', { className: 'page' },
+      h('div', { className: 'loading-state' }, 'Loading...')
+    );
   }
 
-  return h('div', { style: { padding: '2rem' } },
-    h('h2', { style: { color: '#e74c3c' } }, 'Admin Panel'),
+  const isRunning = jobStatus?.status === 'RUNNING';
+  const messages = Object.entries(jobStatus?.messages || {})
+    .sort((a, b) => new Date(a[0]) - new Date(b[0]));
 
-    h('div', { style: { marginBottom: '2rem' } },
-      h('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' } },
-        h('h3', null,
-          'Import Job ',
-          jobStatus?.status === 'RUNNING' && h('span', { style: { color: '#f39c12', fontSize: '0.875rem' } }, '(🔴 Live)')
-        ),
-        h('button', {
-          onClick: startImport,
-          disabled: jobStatus?.status === 'RUNNING',
-          style: {
-            padding: '0.5rem 1rem',
-            background: jobStatus?.status === 'RUNNING' ? '#95a5a6' : '#3498db',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: jobStatus?.status === 'RUNNING' ? 'not-allowed' : 'pointer',
-            fontWeight: 'bold',
-            opacity: jobStatus?.status === 'RUNNING' ? 0.6 : 1
-          }
-        }, jobStatus?.status === 'RUNNING' ? 'Import Running...' : 'Start Import')
+  return h('main', { className: 'page' },
+    h('div', { className: 'page-header' },
+      h('h2', { className: 'page-title' }, 'Admin'),
+      h('button', {
+        className: 'button primary',
+        onClick: startImport,
+        disabled: isRunning
+      }, isRunning ? 'Import Running...' : 'Start Import')
+    ),
+
+    h('section', { className: 'section' },
+      h('div', { className: 'section-header' },
+        h('h3', { className: 'section-title' }, 'Import Job'),
+        isRunning && h('span', { className: 'status-badge warning' }, 'Live')
       ),
 
       jobStatus && h('div', {
-        style: {
-          padding: '1rem',
-          border: jobStatus.status === 'RUNNING' ? '2px solid #3498db' : '1px solid #e1e8ed',
-          borderRadius: '8px',
-          background: 'white'
-        }
+        className: `panel ${isRunning ? 'running' : ''}`
       },
-        h('div', { style: { display: 'flex', justifyContent: 'space-between', marginBottom: '0.5rem' } },
+        h('div', { className: 'section-header' },
           h('div', null,
-            h('span', { style: { fontWeight: 'bold' } }, 'Import Job'),
-            h('span', {
-              style: {
-                marginLeft: '0.5rem',
-                padding: '0.25rem 0.75rem',
-                borderRadius: '4px',
-                fontSize: '0.75rem',
-                background: jobStatus.status === 'COMPLETED' ? '#d5f4e6' :
-                           jobStatus.status === 'FAILED' ? '#fadbd8' :
-                           jobStatus.status === 'RUNNING' ? '#fff3cd' : '#e1e8ed',
-                color: jobStatus.status === 'COMPLETED' ? '#27ae60' :
-                       jobStatus.status === 'FAILED' ? '#e74c3c' :
-                       jobStatus.status === 'RUNNING' ? '#f39c12' : '#7f8c8d'
-              }
-            }, jobStatus.status)
+            h('div', { className: 'item-title' }, 'Import Job'),
+            h('div', { className: 'item-subtitle' },
+              'Started: ', new Date(jobStatus.startedAt).toLocaleString()
+            )
           ),
-          h('div', { style: { color: '#7f8c8d', fontSize: '0.875rem' } },
-            'Started: ', new Date(jobStatus.startedAt).toLocaleString()
-          )
+          h('span', { className: statusClass(jobStatus.status) }, jobStatus.status)
         ),
 
-        Object.keys(jobStatus.messages).length > 0 && h('div', {
-          style: {
-            marginTop: '1rem',
-            marginBottom: '1rem',
-            border: '1px solid #e1e8ed',
-            borderRadius: '4px',
-            background: '#f8f9fa',
-            maxHeight: '300px',
-            overflowY: 'auto'
-          }
-        },
-          h('div', {
-            style: {
-              padding: '0.5rem 1rem',
-              borderBottom: '1px solid #e1e8ed',
-              fontWeight: 'bold',
-              fontSize: '0.875rem',
-              background: '#ecf0f1',
-              position: 'sticky',
-              top: 0,
-              zIndex: 1
-            }
-          }, 'Import Log'),
-          h('div', {
-            style: {
-              padding: '0.5rem',
-              fontFamily: 'monospace',
-              fontSize: '0.75rem'
-            }
-          },
-            Object.entries(jobStatus.messages)
-              .sort((a, b) => new Date(a[0]) - new Date(b[0]))
-              .map(([timestamp, msg]) =>
-                h('div', {
-                  key: timestamp,
-                  style: {
-                    padding: '0.25rem 0.5rem',
-                    borderBottom: '1px solid #ecf0f1',
-                    display: 'flex',
-                    gap: '0.75rem'
-                  }
-                },
-                  h('span', {
-                    style: {
-                      color: '#7f8c8d',
-                      whiteSpace: 'nowrap',
-                      flexShrink: 0
-                    }
-                  }, new Date(timestamp).toLocaleTimeString()),
-                  h('span', {
-                    style: {
-                      color: '#34495e',
-                      wordBreak: 'break-word'
-                    }
-                  }, msg)
-                )
+        messages.length > 0 && h('div', { className: 'job-log' },
+          h('div', { className: 'job-log-title' }, 'Import Log'),
+          h('div', { className: 'job-log-body' },
+            messages.map(([timestamp, message]) =>
+              h('div', { key: timestamp, className: 'job-log-row' },
+                h('span', { className: 'job-log-time' }, new Date(timestamp).toLocaleTimeString()),
+                h('span', { className: 'job-log-message' }, message)
               )
+            )
           )
         ),
 
-        h('div', {
-          style: {
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))',
-            gap: '0.5rem',
-            fontSize: '0.875rem',
-            color: '#34495e'
-          }
-        },
-          h('div', null, 'Files: ', jobStatus.inpFilesProcessed),
-          h('div', null, 'Added: ', jobStatus.booksAdded),
-          h('div', null, 'Deleted: ', jobStatus.bookDeleted),
-          h('div', { style: { color: '#e74c3c' } }, 'Book Errors: ', jobStatus.bookErrors)
+        h('div', { className: 'metrics-grid' },
+          h('div', { className: 'metric' },
+            h('div', { className: 'metric-label' }, 'Files'),
+            h('div', { className: 'metric-value' }, jobStatus.inpFilesProcessed)
+          ),
+          h('div', { className: 'metric' },
+            h('div', { className: 'metric-label' }, 'Added'),
+            h('div', { className: 'metric-value' }, jobStatus.booksAdded)
+          ),
+          h('div', { className: 'metric' },
+            h('div', { className: 'metric-label' }, 'Deleted'),
+            h('div', { className: 'metric-value' }, jobStatus.bookDeleted)
+          ),
+          h('div', { className: 'metric' },
+            h('div', { className: 'metric-label' }, 'Book Errors'),
+            h('div', { className: 'metric-value danger-text' }, jobStatus.bookErrors)
+          )
         ),
 
         jobStatus.completedAt && h('div', {
-          style: { color: '#7f8c8d', fontSize: '0.875rem', marginTop: '0.5rem' }
+          className: 'item-note completed-note'
         }, 'Completed: ', new Date(jobStatus.completedAt).toLocaleString())
       ),
 
       !jobStatus && h('div', {
-        style: { textAlign: 'center', padding: '2rem', color: '#95a5a6' }
-      }, 'No job information available')
+        className: 'empty-state'
+      }, 'No job information available.')
     ),
 
-    h('div', null,
-      h('h3', null, 'Pending User Approvals (', pendingUsers.length, ')'),
-      h('div', { style: { display: 'flex', flexDirection: 'column', gap: '0.75rem' } },
+    h('section', { className: 'section' },
+      h('div', { className: 'section-header' },
+        h('h3', { className: 'section-title' }, 'Pending User Approvals'),
+        h('span', { className: 'chip' }, pendingUsers.length)
+      ),
+      h('div', { className: 'list-stack' },
         pendingUsers.map(user =>
-          h('div', {
-            key: user.id,
-            style: {
-              padding: '1rem',
-              border: '1px solid #e1e8ed',
-              borderRadius: '8px',
-              background: 'white',
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center'
-            }
-          },
-            h('div', { style: { display: 'flex', gap: '0.75rem', alignItems: 'center' } },
+          h('div', { key: user.id, className: 'list-item' },
+            h('div', { className: 'list-item-main' },
               user.avatarUrl && h('img', {
+                className: 'avatar',
                 src: user.avatarUrl,
-                alt: user.name,
-                style: { width: '48px', height: '48px', borderRadius: '50%' }
+                alt: user.name
               }),
               h('div', null,
-                h('div', { style: { fontWeight: 'bold' } }, user.name),
-                h('div', { style: { color: '#7f8c8d', fontSize: '0.875rem' } }, user.email),
-                h('div', { style: { color: '#95a5a6', fontSize: '0.75rem' } },
+                h('div', { className: 'item-title' }, user.name),
+                h('div', { className: 'item-subtitle' }, user.email),
+                h('div', { className: 'item-note' },
                   'Requested: ', new Date(user.createdAt).toLocaleString()
                 )
               )
             ),
-            h('div', { style: { display: 'flex', gap: '0.5rem' } },
+            h('div', { className: 'toolbar' },
               h('button', {
-                onClick: () => approveUser(user.id),
-                style: {
-                  padding: '0.5rem 1rem',
-                  background: '#27ae60',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer'
-                }
+                className: 'button success compact',
+                onClick: () => approveUser(user.id)
               }, 'Approve'),
               h('button', {
-                onClick: () => rejectUser(user.id),
-                style: {
-                  padding: '0.5rem 1rem',
-                  background: '#e74c3c',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '4px',
-                  cursor: 'pointer'
-                }
+                className: 'button danger compact',
+                onClick: () => rejectUser(user.id)
               }, 'Reject')
             )
           )
@@ -275,8 +195,8 @@ export function AdminPanel() {
       ),
 
       pendingUsers.length === 0 && h('div', {
-        style: { textAlign: 'center', padding: '2rem', color: '#95a5a6' }
-      }, 'No pending user approvals')
+        className: 'empty-state'
+      }, 'No pending user approvals.')
     )
   );
 }

--- a/src/main/resources/static/js/components/BookCard.js
+++ b/src/main/resources/static/js/components/BookCard.js
@@ -1,66 +1,36 @@
 import { h } from 'preact';
 
 export function BookCard({ book, onSelect }) {
-  return h('div', {
-    style: {
-      border: '1px solid #ddd',
-      borderRadius: '8px',
-      padding: '1rem',
-      background: 'white',
-      boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
-      cursor: 'pointer',
-      transition: 'transform 0.2s, box-shadow 0.2s'
-    },
+  const authors = (book.authors || []).join(', ');
+
+  return h('article', {
+    className: 'book-card',
     onClick: () => onSelect(book.id),
-    onMouseOver: (e) => {
-      e.currentTarget.style.transform = 'translateY(-2px)';
-      e.currentTarget.style.boxShadow = '0 4px 8px rgba(0,0,0,0.1)';
-    },
-    onMouseOut: (e) => {
-      e.currentTarget.style.transform = 'translateY(0)';
-      e.currentTarget.style.boxShadow = '0 2px 4px rgba(0,0,0,0.05)';
+    tabIndex: 0,
+    onKeyDown: (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onSelect(book.id);
+      }
     }
   },
-    book.coverImageUrl && h('img', {
-      src: book.coverImageUrl,
-      alt: book.title,
-      style: {
-        width: '100%',
-        height: '200px',
-        objectFit: 'cover',
-        borderRadius: '4px',
-        marginBottom: '0.75rem'
-      }
-    }),
-    h('h3', { style: { margin: '0 0 0.5rem 0', fontSize: '1rem' } }, book.title),
-    h('p', { style: { margin: '0 0 0.25rem 0', color: '#7f8c8d', fontSize: '0.875rem' } },
-      (book.authors || []).join(', ')
+    h('div', { className: 'book-cover' },
+      book.coverImageUrl
+        ? h('img', { src: book.coverImageUrl, alt: book.title })
+        : h('div', { className: 'book-cover-placeholder' }, 'No cover')
     ),
-    book.series && h('p', { style: { margin: '0 0 0.25rem 0', color: '#95a5a6', fontSize: '0.75rem' } },
-      book.series, book.seriesNumber ? ` #${book.seriesNumber}` : ''
-    ),
-    h('div', { style: { display: 'flex', gap: '0.5rem', marginTop: '0.5rem', flexWrap: 'wrap' } },
-      (book.genres || []).map(genre =>
-        h('span', {
-          key: genre,
-          style: {
-            background: '#ecf0f1',
-            padding: '0.25rem 0.5rem',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            color: '#34495e'
-          }
-        }, genre)
+    h('div', { className: 'book-card-body' },
+      h('h3', { className: 'book-title' }, book.title),
+      authors && h('p', { className: 'book-meta' }, authors),
+      book.series && h('p', { className: 'book-series' },
+        book.series, book.seriesNumber ? ` #${book.seriesNumber}` : ''
       ),
-      h('span', {
-        style: {
-          background: '#e8f4f8',
-          padding: '0.25rem 0.5rem',
-          borderRadius: '4px',
-          fontSize: '0.75rem',
-          color: '#2980b9'
-        }
-      }, book.language)
+      h('div', { className: 'chip-row' },
+        (book.genres || []).slice(0, 3).map(genre =>
+          h('span', { key: genre, className: 'chip' }, genre)
+        ),
+        book.language && h('span', { className: 'chip accent' }, book.language)
+      )
     )
   );
 }

--- a/src/main/resources/static/js/components/BookDetail.js
+++ b/src/main/resources/static/js/components/BookDetail.js
@@ -72,119 +72,90 @@ export function BookDetail({ bookId, onBack, onSelectBook }) {
   };
 
   if (loading) {
-    return h('div', { style: { padding: '2rem', textAlign: 'center' } }, 'Loading...');
+    return h('main', { className: 'page' },
+      h('div', { className: 'loading-state' }, 'Loading...')
+    );
   }
 
   if (!book) {
-    return h('div', { style: { padding: '2rem' } }, 'Book not found');
+    return h('main', { className: 'page' },
+      h('div', { className: 'empty-state' }, 'Book not found')
+    );
   }
 
-  return h('div', { style: { padding: '2rem' } },
-    h('button', {
-      onClick: onBack,
-      style: {
-        marginBottom: '1rem',
-        padding: '0.5rem 1rem',
-        background: '#95a5a6',
-        color: 'white',
-        border: 'none',
-        borderRadius: '4px',
-        cursor: 'pointer'
-      }
-    }, 'Back'),
+  return h('main', { className: 'page wide' },
+    h('div', { className: 'page-header' },
+      h('button', {
+        className: 'button ghost',
+        onClick: onBack
+      }, 'Back'),
+      h('span', { className: 'soft' }, book.language)
+    ),
 
-    h('div', { style: { display: 'grid', gridTemplateColumns: '300px 1fr', gap: '2rem', marginBottom: '2rem' } },
-      h('div', null,
-        book.coverImageUrl && h('img', {
-          src: book.coverImageUrl,
-          alt: book.title,
-          style: { width: '100%', borderRadius: '8px', marginBottom: '1rem' }
-        }),
-
-        h('div', { style: { marginTop: '1rem' } },
-          h('h4', { style: { marginBottom: '0.5rem' } }, 'Download'),
-          h('button', buttonStyle('#3498db', { marginBottom: '0.25rem' }, () => download('fb2')), 'Download FB2'),
-          h('button', buttonStyle('#3498db', {}, () => download('epub')), 'Download EPUB')
+    h('div', { className: 'detail-layout' },
+      h('aside', null,
+        h('div', { className: 'detail-cover' },
+          book.coverImageUrl
+            ? h('img', { src: book.coverImageUrl, alt: book.title })
+            : h('div', { className: 'book-cover-placeholder large' }, 'No cover')
         ),
 
-        h('div', { style: { marginTop: '1rem' } },
-          h('h4', { style: { marginBottom: '0.5rem' } }, 'Send to Kindle'),
-          kindleDevices.length === 0
-            ? h('p', { style: { color: '#95a5a6', fontSize: '0.875rem' } },
-                'No Kindle devices yet. Add one in the Kindle section.')
-            : h('div', null,
-                h('select', {
-                  value: selectedDeviceId,
-                  onChange: (e) => setSelectedDeviceId(e.target.value),
-                  style: {
-                    width: '100%',
-                    padding: '0.5rem',
-                    marginBottom: '0.25rem',
-                    border: '1px solid #ddd',
-                    borderRadius: '4px',
-                    boxSizing: 'border-box'
-                  }
-                }, kindleDevices.map(d =>
-                  h('option', { key: d.id, value: String(d.id) }, `${d.name} (${d.email})`)
-                )),
-                h('button', {
-                  ...buttonStyle(sendingToKindle ? '#95a5a6' : '#9b59b6', {}, sendToKindle),
-                  disabled: sendingToKindle || !selectedDeviceId
-                }, sendingToKindle ? 'Sending...' : 'Send EPUB to Kindle')
-              )
+        h('div', { className: 'side-actions' },
+          h('section', { className: 'panel' },
+            h('h3', { className: 'section-title' }, 'Download'),
+            h('div', { className: 'action-stack' },
+              h('button', { className: 'button full', onClick: () => download('fb2') }, 'FB2'),
+              h('button', { className: 'button full', onClick: () => download('epub') }, 'EPUB')
+            )
+          ),
+
+          h('section', { className: 'panel' },
+            h('h3', { className: 'section-title' }, 'Send to Kindle'),
+            kindleDevices.length === 0
+              ? h('p', { className: 'book-meta' },
+                  'Add a Kindle device before sending EPUB files.'
+                )
+              : h('div', { className: 'action-stack' },
+                  h('select', {
+                    className: 'select',
+                    value: selectedDeviceId,
+                    onChange: (event) => setSelectedDeviceId(event.target.value)
+                  }, kindleDevices.map(device =>
+                    h('option', { key: device.id, value: String(device.id) }, `${device.name} (${device.email})`)
+                  )),
+                  h('button', {
+                    className: 'button primary full',
+                    onClick: sendToKindle,
+                    disabled: sendingToKindle || !selectedDeviceId
+                  }, sendingToKindle ? 'Sending...' : 'Send EPUB')
+                )
+          )
         )
       ),
 
-      h('div', null,
-        h('h1', { style: { marginTop: 0 } }, book.title),
-        h('p', { style: { fontSize: '1.125rem', color: '#7f8c8d', marginBottom: '1rem' } },
-          book.authors.map(a => a.fullName).join(', ')
+      h('article', null,
+        h('h1', { className: 'detail-title' }, book.title),
+        h('p', { className: 'detail-author' },
+          book.authors.map(author => author.fullName).join(', ')
         ),
-        book.series && h('p', { style: { color: '#95a5a6', marginBottom: '1rem' } },
+        book.series && h('p', { className: 'book-meta' },
           'Series: ', book.series.name, book.seriesNumber ? ` #${book.seriesNumber}` : ''
         ),
-        h('div', { style: { display: 'flex', gap: '0.5rem', marginBottom: '1rem', flexWrap: 'wrap' } },
+        h('div', { className: 'chip-row' },
           (book.genres || []).map(genre =>
-            h('span', {
-              key: genre,
-              style: {
-                background: '#ecf0f1',
-                padding: '0.5rem 1rem',
-                borderRadius: '4px',
-                color: '#34495e'
-              }
-            }, genre)
+            h('span', { key: genre, className: 'chip' }, genre)
           ),
-          h('span', {
-            style: {
-              background: '#e8f4f8',
-              padding: '0.5rem 1rem',
-              borderRadius: '4px',
-              color: '#2980b9'
-            }
-          }, book.language)
+          book.language && h('span', { className: 'chip accent' }, book.language)
         ),
-        book.annotation && h('div', {
-          style: {
-            background: '#f8f9fa',
-            padding: '1rem',
-            borderRadius: '8px',
-            marginBottom: '2rem',
-            whiteSpace: 'pre-wrap'
-          }
-        }, book.annotation)
+        book.annotation && h('div', { className: 'annotation' }, book.annotation)
       )
     ),
 
-    similarBooks.length > 0 && h('div', { style: { marginTop: '3rem' } },
-      h('h2', { style: { marginBottom: '1rem' } }, 'Similar Books'),
-      h('div', {
-        style: {
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-          gap: '1rem'
-        }
-      },
+    similarBooks.length > 0 && h('section', { className: 'section' },
+      h('div', { className: 'section-header' },
+        h('h2', { className: 'section-title' }, 'Similar Books')
+      ),
+      h('div', { className: 'book-grid' },
         similarBooks.map(book =>
           h(BookCard, {
             key: book.id,
@@ -195,20 +166,4 @@ export function BookDetail({ bookId, onBack, onSelectBook }) {
       )
     )
   );
-}
-
-function buttonStyle(background, extraStyle, onClick) {
-  return {
-    onClick,
-    style: {
-      width: '100%',
-      padding: '0.5rem',
-      background,
-      color: 'white',
-      border: 'none',
-      borderRadius: '4px',
-      cursor: 'pointer',
-      ...extraStyle
-    }
-  };
 }

--- a/src/main/resources/static/js/components/BooksList.js
+++ b/src/main/resources/static/js/components/BooksList.js
@@ -89,20 +89,16 @@ export function BooksList({ onSelectBook, initialOffset = 0, onPageChange }) {
   const rangeStart = total === 0 ? 0 : offset + 1;
   const rangeEnd = Math.min(offset + limit, total);
 
-  return h('div', { style: { padding: '2rem' } },
-    h('h2', null, 'Books'),
+  return h('main', { className: 'page wide' },
+    h('div', { className: 'page-header' },
+      h('h2', { className: 'page-title' }, 'Books'),
+      h('span', { className: 'muted' }, `${total} total`)
+    ),
     h(SearchBar, { onSearch: handleSearch }),
 
     loading
-      ? h('div', { style: { textAlign: 'center', padding: '2rem' } }, 'Loading...')
-      : h('div', {
-          style: {
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
-            gap: '1.5rem',
-            marginBottom: '2rem'
-          }
-        },
+      ? h('div', { className: 'loading-state' }, 'Loading...')
+      : h('div', { className: 'book-grid' },
         books.map(book =>
           h(BookCard, {
             key: book.id,
@@ -113,36 +109,22 @@ export function BooksList({ onSelectBook, initialOffset = 0, onPageChange }) {
       ),
 
     books.length === 0 && !loading && h('div', {
-      style: { textAlign: 'center', padding: '2rem', color: '#95a5a6' }
+      className: 'empty-state'
     }, 'No books found'),
 
-    h('div', { style: { display: 'flex', justifyContent: 'center', gap: '1rem', marginTop: '2rem' } },
+    h('div', { className: 'pagination' },
       h('button', {
+        className: 'button',
         onClick: handlePreviousPage,
-        disabled: offset === 0,
-        style: {
-          padding: '0.75rem 1.5rem',
-          background: offset === 0 ? '#ecf0f1' : '#3498db',
-          color: offset === 0 ? '#95a5a6' : 'white',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: offset === 0 ? 'not-allowed' : 'pointer'
-        }
+        disabled: offset === 0
       }, 'Previous'),
-      h('span', { style: { padding: '0.75rem', color: '#7f8c8d' } },
+      h('span', { className: 'range-label' },
         `${rangeStart}-${rangeEnd} of ${total}`
       ),
       h('button', {
+        className: 'button',
         onClick: handleNextPage,
-        disabled: !hasMore,
-        style: {
-          padding: '0.75rem 1.5rem',
-          background: !hasMore ? '#ecf0f1' : '#3498db',
-          color: !hasMore ? '#95a5a6' : 'white',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: !hasMore ? 'not-allowed' : 'pointer'
-        }
+        disabled: !hasMore
       }, 'Next')
     )
   );

--- a/src/main/resources/static/js/components/ErrorPage.js
+++ b/src/main/resources/static/js/components/ErrorPage.js
@@ -1,91 +1,22 @@
 import { h } from 'preact';
 
 export function ErrorPage({ error, onRetry }) {
-  return h('div', {
-    style: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      minHeight: '100vh',
-      background: '#ecf0f1',
-      padding: '2rem'
-    }
-  },
-    h('div', {
-      style: {
-        background: 'white',
-        borderRadius: '16px',
-        padding: '3rem',
-        boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
-        maxWidth: '500px',
-        width: '100%',
-        textAlign: 'center'
-      }
-    },
-      h('div', { style: { fontSize: '4rem', marginBottom: '1rem' } }, '⚠️'),
-      h('h1', {
-        style: {
-          margin: '0 0 1rem 0',
-          fontSize: '2rem',
-          color: '#e74c3c'
-        }
-      }, 'Server Error'),
-      h('p', {
-        style: {
-          margin: '0 0 2rem 0',
-          color: '#7f8c8d',
-          lineHeight: '1.6'
-        }
-      }, 'There was an error connecting to the server. This could be a database connection issue.'),
-      h('div', {
-        style: {
-          background: '#f8f9fa',
-          padding: '1rem',
-          borderRadius: '8px',
-          marginBottom: '2rem',
-          textAlign: 'left'
-        }
-      },
-        h('p', { style: { margin: '0 0 0.5rem 0', fontWeight: 'bold', fontSize: '0.875rem' } },
-          'Error details:'
-        ),
-        h('p', {
-          style: {
-            margin: 0,
-            fontSize: '0.875rem',
-            color: '#e74c3c',
-            fontFamily: 'monospace',
-            wordBreak: 'break-word'
-          }
-        }, error)
+  return h('main', { className: 'auth-page' },
+    h('section', { className: 'error-card' },
+      h('div', { className: 'error-mark', 'aria-hidden': 'true' }, '!'),
+      h('h1', { className: 'error-title' }, 'Server Error'),
+      h('p', { className: 'error-copy' },
+        'There was an error connecting to the server.'
       ),
-      h('div', { style: { display: 'flex', gap: '1rem', justifyContent: 'center' } },
+      h('div', { className: 'error-details' }, error),
+      h('div', { className: 'form-actions center' },
         h('button', {
-          onClick: onRetry,
-          style: {
-            padding: '0.75rem 1.5rem',
-            background: '#3498db',
-            color: 'white',
-            border: 'none',
-            borderRadius: '8px',
-            fontSize: '1rem',
-            fontWeight: '600',
-            cursor: 'pointer'
-          }
+          className: 'button primary',
+          onClick: onRetry
         }, 'Retry'),
         h('a', {
           href: '/logout',
-          style: {
-            padding: '0.75rem 1.5rem',
-            background: '#95a5a6',
-            color: 'white',
-            border: 'none',
-            borderRadius: '8px',
-            fontSize: '1rem',
-            fontWeight: '600',
-            textDecoration: 'none',
-            display: 'inline-block'
-          }
+          className: 'button'
         }, 'Logout')
       )
     )

--- a/src/main/resources/static/js/components/Header.js
+++ b/src/main/resources/static/js/components/Header.js
@@ -1,65 +1,39 @@
 import { h } from 'preact';
 
+function navClass(view, currentView, extra = '') {
+  return `nav-button ${currentView === view ? 'active' : ''} ${extra}`.trim();
+}
+
 export function Header({ user, onNavigate, currentView, isAdmin }) {
-  return h('header', {
-    style: {
-      background: '#2c3e50',
-      color: 'white',
-      padding: '1rem 2rem',
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
-    }
-  },
-    h('div', null,
-      h('h1', { style: { margin: 0, fontSize: '1.5rem' } }, '📚 Kotbusta')
+  return h('header', { className: 'site-header' },
+    h('div', { className: 'brand' },
+      h('span', { className: 'brand-mark', 'aria-hidden': 'true' }, 'K'),
+      h('h1', { className: 'brand-title' }, 'Kotbusta')
     ),
-    h('nav', { style: { display: 'flex', gap: '1rem', alignItems: 'center' } },
+    h('nav', { className: 'top-nav', 'aria-label': 'Primary navigation' },
       h('button', {
-        onClick: () => onNavigate('books'),
-        style: {
-          background: currentView === 'books' ? '#34495e' : 'transparent',
-          border: 'none',
-          color: 'white',
-          padding: '0.5rem 1rem',
-          cursor: 'pointer',
-          borderRadius: '4px'
-        }
+        className: navClass('books', currentView),
+        onClick: () => onNavigate('books')
       }, 'Books'),
       h('button', {
-        onClick: () => onNavigate('kindle'),
-        style: {
-          background: currentView === 'kindle' ? '#34495e' : 'transparent',
-          border: 'none',
-          color: 'white',
-          padding: '0.5rem 1rem',
-          cursor: 'pointer',
-          borderRadius: '4px'
-        }
+        className: navClass('kindle', currentView),
+        onClick: () => onNavigate('kindle')
       }, 'Kindle'),
       isAdmin && h('button', {
-        onClick: () => onNavigate('admin'),
-        style: {
-          background: currentView === 'admin' ? '#e74c3c' : '#c0392b',
-          border: 'none',
-          color: 'white',
-          padding: '0.5rem 1rem',
-          cursor: 'pointer',
-          borderRadius: '4px'
-        }
+        className: navClass('admin', currentView, 'admin'),
+        onClick: () => onNavigate('admin')
       }, 'Admin')
     ),
-    h('div', { style: { display: 'flex', alignItems: 'center', gap: '1rem' } },
-      user && h('div', { style: { display: 'flex', alignItems: 'center', gap: '0.5rem' } },
+    h('div', { className: 'user-menu' },
+      user && h('div', { className: 'user-identity' },
         user.data.avatarUrl && h('img', {
+          className: 'avatar',
           src: user.data.avatarUrl,
-          alt: user.data.name,
-          style: { width: '32px', height: '32px', borderRadius: '50%' }
+          alt: user.data.name
         }),
         h('span', null, user.data.name)
       ),
-      h('a', { href: '/logout', style: { color: 'white', textDecoration: 'none' } }, 'Logout')
+      h('a', { href: '/logout', className: 'logout-link' }, 'Logout')
     )
   );
 }

--- a/src/main/resources/static/js/components/KindleManagement.js
+++ b/src/main/resources/static/js/components/KindleManagement.js
@@ -2,6 +2,13 @@ import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import { api } from '../utils/api.js';
 
+function statusClass(status) {
+  if (status === 'COMPLETED') return 'status-badge success';
+  if (status === 'FAILED') return 'status-badge danger';
+  if (status === 'PROCESSING') return 'status-badge warning';
+  return 'status-badge';
+}
+
 export function KindleManagement() {
   const [devices, setDevices] = useState([]);
   const [sendHistory, setSendHistory] = useState([]);
@@ -28,8 +35,8 @@ export function KindleManagement() {
     }
   };
 
-  const addDevice = async (e) => {
-    e.preventDefault();
+  const addDevice = async (event) => {
+    event.preventDefault();
     try {
       await api.post('/api/kindle/devices', newDevice);
       setNewDevice({ email: '', name: '' });
@@ -51,179 +58,104 @@ export function KindleManagement() {
   };
 
   if (loading) {
-    return h('div', { style: { padding: '2rem', textAlign: 'center' } }, 'Loading...');
+    return h('main', { className: 'page' },
+      h('div', { className: 'loading-state' }, 'Loading...')
+    );
   }
 
-  return h('div', { style: { padding: '2rem' } },
-    h('h2', null, 'Kindle Management'),
+  return h('main', { className: 'page' },
+    h('div', { className: 'page-header' },
+      h('h2', { className: 'page-title' }, 'Kindle'),
+      h('button', {
+        className: 'button primary',
+        onClick: () => setShowAddDevice(!showAddDevice)
+      }, showAddDevice ? 'Close' : 'Add Device')
+    ),
 
-    h('div', { style: { marginBottom: '2rem' } },
-      h('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem' } },
-        h('h3', null, 'My Devices'),
-        h('button', {
-          onClick: () => setShowAddDevice(!showAddDevice),
-          style: {
-            padding: '0.5rem 1rem',
-            background: '#27ae60',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            cursor: 'pointer'
-          }
-        }, '+ Add Device')
+    h('section', { className: 'section' },
+      h('div', { className: 'section-header' },
+        h('h3', { className: 'section-title' }, 'My Devices')
       ),
 
       showAddDevice && h('form', {
-        onSubmit: addDevice,
-        style: {
-          background: '#ecf0f1',
-          padding: '1rem',
-          borderRadius: '8px',
-          marginBottom: '1rem'
-        }
+        className: 'form-panel',
+        onSubmit: addDevice
       },
         h('input', {
+          className: 'input',
           type: 'email',
           value: newDevice.email,
-          onInput: (e) => setNewDevice({ ...newDevice, email: e.target.value }),
-          placeholder: 'Kindle Email (e.g., user@kindle.com)',
-          required: true,
-          style: {
-            width: '100%',
-            padding: '0.75rem',
-            border: '1px solid #bdc3c7',
-            borderRadius: '4px',
-            marginBottom: '0.5rem',
-            boxSizing: 'border-box'
-          }
+          onInput: (event) => setNewDevice({ ...newDevice, email: event.target.value }),
+          placeholder: 'Kindle email, for example user@kindle.com',
+          required: true
         }),
         h('input', {
+          className: 'input',
           type: 'text',
           value: newDevice.name,
-          onInput: (e) => setNewDevice({ ...newDevice, name: e.target.value }),
-          placeholder: 'Device Name (e.g., My Kindle)',
-          required: true,
-          style: {
-            width: '100%',
-            padding: '0.75rem',
-            border: '1px solid #bdc3c7',
-            borderRadius: '4px',
-            marginBottom: '0.5rem',
-            boxSizing: 'border-box'
-          }
+          onInput: (event) => setNewDevice({ ...newDevice, name: event.target.value }),
+          placeholder: 'Device name',
+          required: true
         }),
-        h('div', { style: { display: 'flex', gap: '0.5rem' } },
+        h('div', { className: 'form-actions' },
+          h('button', { className: 'button success', type: 'submit' }, 'Add'),
           h('button', {
-            type: 'submit',
-            style: {
-              padding: '0.5rem 1rem',
-              background: '#27ae60',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer'
-            }
-          }, 'Add'),
-          h('button', {
+            className: 'button',
             type: 'button',
-            onClick: () => setShowAddDevice(false),
-            style: {
-              padding: '0.5rem 1rem',
-              background: '#95a5a6',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: 'pointer'
-            }
+            onClick: () => setShowAddDevice(false)
           }, 'Cancel')
         )
       ),
 
-      h('div', { style: { display: 'flex', flexDirection: 'column', gap: '0.75rem' } },
+      h('div', { className: 'list-stack' },
         devices.map(device =>
-          h('div', {
-            key: device.id,
-            style: {
-              padding: '1rem',
-              border: '1px solid #e1e8ed',
-              borderRadius: '8px',
-              background: 'white',
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center'
-            }
-          },
+          h('div', { key: device.id, className: 'list-item' },
             h('div', null,
-              h('div', { style: { fontWeight: 'bold' } }, device.name),
-              h('div', { style: { color: '#7f8c8d', fontSize: '0.875rem' } }, device.email)
+              h('div', { className: 'item-title' }, device.name),
+              h('div', { className: 'item-subtitle' }, device.email)
             ),
             h('button', {
-              onClick: () => deleteDevice(device.id),
-              style: {
-                padding: '0.5rem 1rem',
-                background: '#e74c3c',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer'
-              }
+              className: 'button danger compact',
+              onClick: () => deleteDevice(device.id)
             }, 'Delete')
           )
         )
       ),
 
       devices.length === 0 && h('div', {
-        style: { textAlign: 'center', padding: '2rem', color: '#95a5a6' }
-      }, 'No devices yet. Add your first Kindle device to get started!')
+        className: 'empty-state'
+      }, 'No devices yet.')
     ),
 
-    h('div', null,
-      h('h3', null, 'Send History'),
-      h('div', { style: { display: 'flex', flexDirection: 'column', gap: '0.5rem' } },
+    h('section', { className: 'section' },
+      h('div', { className: 'section-header' },
+        h('h3', { className: 'section-title' }, 'Send History')
+      ),
+      h('div', { className: 'list-stack' },
         sendHistory.map(item =>
-          h('div', {
-            key: item.id,
-            style: {
-              padding: '0.75rem',
-              border: '1px solid #e1e8ed',
-              borderRadius: '4px',
-              background: 'white'
-            }
-          },
-            h('div', { style: { display: 'flex', justifyContent: 'space-between', alignItems: 'start' } },
+          h('div', { key: item.id, className: 'list-item history-row' },
+            h('div', { className: 'history-topline' },
               h('div', null,
-                h('div', { style: { fontWeight: 'bold' } }, item.bookTitle),
-                h('div', { style: { color: '#7f8c8d', fontSize: '0.875rem' } },
-                  `to ${item.deviceName} · ${item.format}`
+                h('div', { className: 'item-title' }, item.bookTitle),
+                h('div', { className: 'item-subtitle' },
+                  `to ${item.deviceName} - ${item.format}`
                 ),
-                h('div', { style: { color: '#95a5a6', fontSize: '0.75rem' } },
+                h('div', { className: 'item-note' },
                   new Date(item.createdAt).toLocaleString()
                 )
               ),
-              h('span', {
-                style: {
-                  padding: '0.25rem 0.75rem',
-                  borderRadius: '4px',
-                  fontSize: '0.75rem',
-                  background: item.status === 'COMPLETED' ? '#d5f4e6' :
-                             item.status === 'FAILED' ? '#fadbd8' :
-                             item.status === 'PROCESSING' ? '#fff3cd' : '#e8f4f8',
-                  color: item.status === 'COMPLETED' ? '#27ae60' :
-                         item.status === 'FAILED' ? '#e74c3c' :
-                         item.status === 'PROCESSING' ? '#f39c12' : '#3498db'
-                }
-              }, item.status)
+              h('span', { className: statusClass(item.status) }, item.status)
             ),
             item.lastError && h('div', {
-              style: { color: '#e74c3c', fontSize: '0.75rem', marginTop: '0.5rem' }
+              className: 'error-text'
             }, `Error: ${item.lastError}`)
           )
         )
       ),
 
       sendHistory.length === 0 && h('div', {
-        style: { textAlign: 'center', padding: '2rem', color: '#95a5a6' }
-      }, 'No send history yet')
+        className: 'empty-state'
+      }, 'No send history yet.')
     )
   );
 }

--- a/src/main/resources/static/js/components/LoginPage.js
+++ b/src/main/resources/static/js/components/LoginPage.js
@@ -1,118 +1,16 @@
 import { h } from 'preact';
 
 export function LoginPage() {
-  return h('div', {
-    style: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      minHeight: '100vh',
-      background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-      padding: '2rem'
-    }
-  },
-    h('div', {
-      style: {
-        background: 'white',
-        borderRadius: '16px',
-        padding: '3rem',
-        boxShadow: '0 20px 60px rgba(0,0,0,0.3)',
-        maxWidth: '500px',
-        width: '100%',
-        textAlign: 'center'
-      }
-    },
-      h('div', { style: { fontSize: '4rem', marginBottom: '1rem' } }, '📚'),
-      h('h1', {
-        style: {
-          margin: '0 0 0.5rem 0',
-          fontSize: '2.5rem',
-          color: '#2c3e50',
-          fontWeight: '700'
-        }
-      }, 'Kotbusta'),
-      h('p', {
-        style: {
-          margin: '0 0 2rem 0',
-          fontSize: '1.125rem',
-          color: '#7f8c8d',
-          lineHeight: '1.6'
-        }
-      }, 'Your personal digital library'),
-
-      h('div', {
-        style: {
-          background: '#f8f9fa',
-          borderRadius: '8px',
-          padding: '1.5rem',
-          marginBottom: '2rem'
-        }
-      },
-        h('p', { style: { margin: '0 0 1rem 0', color: '#34495e', fontSize: '0.875rem' } },
-          'Access your book catalog, search the collection, and send books to your Kindle device.'
-        ),
-        h('ul', {
-          style: {
-            listStyle: 'none',
-            padding: 0,
-            margin: 0,
-            textAlign: 'left',
-            color: '#7f8c8d',
-            fontSize: '0.875rem'
-          }
-        },
-          h('li', { style: { padding: '0.5rem 0' } }, '✓ Browse and search book collection'),
-          h('li', { style: { padding: '0.5rem 0' } }, '✓ Download FB2 and EPUB'),
-          h('li', { style: { padding: '0.5rem 0' } }, '✓ Send books directly to Kindle'),
-          h('li', { style: { padding: '0.5rem 0' } }, '✓ Admin-managed imports')
-        )
-      ),
-
+  return h('main', { className: 'auth-page' },
+    h('section', { className: 'auth-card' },
+      h('div', { className: 'auth-mark', 'aria-hidden': 'true' }, 'K'),
+      h('h1', { className: 'auth-title' }, 'Kotbusta'),
+      h('p', { className: 'auth-copy' }, 'Sign in to browse, download, and send books to Kindle.'),
       h('a', {
         href: '/login',
-        style: {
-          display: 'inline-flex',
-          alignItems: 'center',
-          gap: '0.75rem',
-          padding: '1rem 2rem',
-          background: '#4285f4',
-          color: 'white',
-          textDecoration: 'none',
-          borderRadius: '8px',
-          fontSize: '1.125rem',
-          fontWeight: '600',
-          boxShadow: '0 4px 12px rgba(66, 133, 244, 0.3)',
-          transition: 'all 0.3s ease',
-          border: 'none',
-          cursor: 'pointer'
-        },
-        onMouseOver: (e) => {
-          e.currentTarget.style.background = '#357ae8';
-          e.currentTarget.style.transform = 'translateY(-2px)';
-          e.currentTarget.style.boxShadow = '0 6px 16px rgba(66, 133, 244, 0.4)';
-        },
-        onMouseOut: (e) => {
-          e.currentTarget.style.background = '#4285f4';
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 4px 12px rgba(66, 133, 244, 0.3)';
-        }
-      },
-        h('svg', { width: '20', height: '20', viewBox: '0 0 24 24', fill: 'white' },
-          h('path', { d: 'M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z' }),
-          h('path', { d: 'M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z' }),
-          h('path', { d: 'M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z' }),
-          h('path', { d: 'M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z' })
-        ),
-        'Sign in with Google'
-      ),
-
-      h('p', {
-        style: {
-          marginTop: '2rem',
-          fontSize: '0.75rem',
-          color: '#95a5a6'
-        }
-      }, 'By signing in, you agree to our terms of service')
+        className: 'button primary full'
+      }, 'Continue with Google'),
+      h('p', { className: 'auth-footnote' }, 'Access is managed by the administrator.')
     )
   );
 }

--- a/src/main/resources/static/js/components/SearchBar.js
+++ b/src/main/resources/static/js/components/SearchBar.js
@@ -6,82 +6,52 @@ export function SearchBar({ onSearch, initialQuery = '' }) {
   const [filters, setFilters] = useState({ genre: '', language: '', author: '' });
   const [showFilters, setShowFilters] = useState(false);
 
-  const handleSearch = (e) => {
-    e.preventDefault();
+  const handleSearch = (event) => {
+    event.preventDefault();
     onSearch({ q: query, ...filters });
   };
 
-  return h('div', { style: { marginBottom: '2rem' } },
-    h('form', { onSubmit: handleSearch, style: { display: 'flex', gap: '0.5rem', marginBottom: '1rem' } },
+  return h('div', { className: 'search-shell' },
+    h('form', { className: 'search-form', onSubmit: handleSearch },
       h('input', {
+        className: 'input',
         type: 'text',
         value: query,
-        onInput: (e) => setQuery(e.target.value),
-        placeholder: 'Search books...',
-        style: {
-          flex: 1,
-          padding: '0.75rem',
-          border: '1px solid #ddd',
-          borderRadius: '4px',
-          fontSize: '1rem'
-        }
+        onInput: (event) => setQuery(event.target.value),
+        placeholder: 'Search books...'
       }),
       h('button', {
+        className: `button ${showFilters ? 'primary' : ''}`,
         type: 'button',
-        onClick: () => setShowFilters(!showFilters),
-        style: {
-          padding: '0.75rem 1rem',
-          background: '#95a5a6',
-          color: 'white',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer'
-        }
+        onClick: () => setShowFilters(!showFilters)
       }, 'Filters'),
       h('button', {
-        type: 'submit',
-        style: {
-          padding: '0.75rem 1.5rem',
-          background: '#3498db',
-          color: 'white',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          fontWeight: 'bold'
-        }
+        className: 'button primary',
+        type: 'submit'
       }, 'Search')
     ),
 
-    showFilters && h('div', {
-      style: {
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-        gap: '1rem',
-        padding: '1rem',
-        background: '#ecf0f1',
-        borderRadius: '4px'
-      }
-    },
+    showFilters && h('div', { className: 'filters-panel' },
       h('input', {
+        className: 'input',
         type: 'text',
         value: filters.genre,
-        onInput: (e) => setFilters({ ...filters, genre: e.target.value }),
-        placeholder: 'Genre',
-        style: { padding: '0.5rem', border: '1px solid #bdc3c7', borderRadius: '4px' }
+        onInput: (event) => setFilters({ ...filters, genre: event.target.value }),
+        placeholder: 'Genre'
       }),
       h('input', {
+        className: 'input',
         type: 'text',
         value: filters.language,
-        onInput: (e) => setFilters({ ...filters, language: e.target.value }),
-        placeholder: 'Language',
-        style: { padding: '0.5rem', border: '1px solid #bdc3c7', borderRadius: '4px' }
+        onInput: (event) => setFilters({ ...filters, language: event.target.value }),
+        placeholder: 'Language'
       }),
       h('input', {
+        className: 'input',
         type: 'text',
         value: filters.author,
-        onInput: (e) => setFilters({ ...filters, author: e.target.value }),
-        placeholder: 'Author',
-        style: { padding: '0.5rem', border: '1px solid #bdc3c7', borderRadius: '4px' }
+        onInput: (event) => setFilters({ ...filters, author: event.target.value }),
+        placeholder: 'Author'
       })
     )
   );

--- a/src/main/resources/static/js/preview.js
+++ b/src/main/resources/static/js/preview.js
@@ -1,0 +1,197 @@
+import { render, h } from 'preact';
+import { useState } from 'preact/hooks';
+import { api } from './utils/api.js';
+import { Header } from './components/Header.js';
+import { BooksList } from './components/BooksList.js';
+import { BookDetail } from './components/BookDetail.js';
+import { KindleManagement } from './components/KindleManagement.js';
+import { AdminPanel } from './components/AdminPanel.js';
+
+const previewUser = {
+  data: {
+    name: 'Preview User',
+    avatarUrl: ''
+  }
+};
+
+const books = [
+  {
+    id: 1,
+    title: 'The Left Hand of Darkness',
+    authors: ['Ursula K. Le Guin'],
+    genres: ['Science Fiction', 'Classic'],
+    language: 'EN',
+    series: 'Hainish Cycle',
+    seriesNumber: 4
+  },
+  {
+    id: 2,
+    title: 'Solaris',
+    authors: ['Stanislaw Lem'],
+    genres: ['Science Fiction', 'Philosophy'],
+    language: 'EN'
+  },
+  {
+    id: 3,
+    title: 'A Wizard of Earthsea',
+    authors: ['Ursula K. Le Guin'],
+    genres: ['Fantasy', 'Coming of Age'],
+    language: 'EN',
+    series: 'Earthsea',
+    seriesNumber: 1
+  },
+  {
+    id: 4,
+    title: 'The Master and Margarita',
+    authors: ['Mikhail Bulgakov'],
+    genres: ['Literary Fiction', 'Satire'],
+    language: 'EN'
+  },
+  {
+    id: 5,
+    title: 'Roadside Picnic',
+    authors: ['Arkady Strugatsky', 'Boris Strugatsky'],
+    genres: ['Science Fiction', 'Adventure'],
+    language: 'EN'
+  },
+  {
+    id: 6,
+    title: 'Invisible Cities',
+    authors: ['Italo Calvino'],
+    genres: ['Literary Fiction', 'Experimental'],
+    language: 'EN'
+  }
+];
+
+const devices = [
+  { id: 1, name: 'Paperwhite', email: 'reader@kindle.com' },
+  { id: 2, name: 'Travel Kindle', email: 'travel@kindle.com' }
+];
+
+const sendHistory = [
+  {
+    id: 1,
+    bookTitle: 'Solaris',
+    deviceName: 'Paperwhite',
+    format: 'EPUB',
+    status: 'COMPLETED',
+    createdAt: new Date(Date.now() - 1000 * 60 * 24).toISOString()
+  },
+  {
+    id: 2,
+    bookTitle: 'Roadside Picnic',
+    deviceName: 'Travel Kindle',
+    format: 'EPUB',
+    status: 'PROCESSING',
+    createdAt: new Date(Date.now() - 1000 * 60 * 8).toISOString()
+  }
+];
+
+function detailBook(id) {
+  const book = books.find(item => item.id === id) || books[0];
+  return {
+    ...book,
+    authors: book.authors.map(fullName => ({ fullName })),
+    series: book.series ? { name: book.series } : null,
+    annotation: 'A compact preview of the refreshed detail view. Metadata, actions, chips, and longer descriptions now sit on a lighter surface with softer borders and more readable spacing.'
+  };
+}
+
+api.get = async (url) => {
+  if (url.startsWith('/api/books?') || url.startsWith('/api/search/books?')) {
+    return { data: { books, total: books.length, hasMore: false } };
+  }
+
+  const bookMatch = url.match(/^\/api\/books\/(\d+)$/);
+  if (bookMatch) {
+    return { data: detailBook(Number(bookMatch[1])) };
+  }
+
+  if (url.match(/^\/api\/books\/(\d+)\/similar$/)) {
+    return { data: books.slice(1, 5) };
+  }
+
+  if (url === '/api/kindle/devices') {
+    return { data: devices };
+  }
+
+  if (url.startsWith('/api/kindle/sends')) {
+    return { data: { items: sendHistory } };
+  }
+
+  if (url === '/api/admin/jobs') {
+    return {
+      data: {
+        status: 'RUNNING',
+        startedAt: new Date(Date.now() - 1000 * 60 * 11).toISOString(),
+        completedAt: null,
+        inpFilesProcessed: 14,
+        booksAdded: 1280,
+        bookDeleted: 9,
+        bookErrors: 2,
+        messages: {
+          [new Date(Date.now() - 1000 * 60 * 10).toISOString()]: 'Reading INPX metadata',
+          [new Date(Date.now() - 1000 * 60 * 7).toISOString()]: 'Updating Lucene index',
+          [new Date(Date.now() - 1000 * 60 * 2).toISOString()]: 'Generating enrichment queue'
+        }
+      }
+    };
+  }
+
+  if (url.startsWith('/api/admin/users/pending')) {
+    return {
+      data: {
+        users: [
+          {
+            id: 1,
+            name: 'Ada Lovelace',
+            email: 'ada@example.com',
+            avatarUrl: '',
+            createdAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString()
+          }
+        ]
+      }
+    };
+  }
+
+  return { data: null };
+};
+
+api.post = async () => ({ data: {} });
+api.delete = async () => ({ data: {} });
+
+function PreviewApp() {
+  const [currentView, setCurrentView] = useState('books');
+  const [selectedBookId, setSelectedBookId] = useState(null);
+
+  const navigate = (view) => {
+    setCurrentView(view);
+    setSelectedBookId(null);
+  };
+
+  return h('div', { className: 'app-shell' },
+    h(Header, {
+      user: previewUser,
+      currentView,
+      onNavigate: navigate,
+      isAdmin: true
+    }),
+    selectedBookId
+      ? h(BookDetail, {
+          bookId: selectedBookId,
+          onBack: () => setSelectedBookId(null),
+          onSelectBook: setSelectedBookId
+        })
+      : [
+          currentView === 'books' && h(BooksList, {
+            onSelectBook: setSelectedBookId,
+            initialOffset: 0,
+            onPageChange: () => {}
+          }),
+          currentView === 'kindle' && h(KindleManagement),
+          currentView === 'admin' && h(AdminPanel)
+        ]
+  );
+}
+
+render(h(PreviewApp), document.getElementById('app'));

--- a/src/main/resources/static/preview.html
+++ b/src/main/resources/static/preview.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kotbusta UI Preview</title>
+    <link rel="stylesheet" href="/styles.css">
+    <script type="importmap">
+    {
+        "imports": {
+            "preact": "https://esm.sh/preact@10.27.1",
+            "preact/hooks": "https://esm.sh/preact@10.27.1/hooks"
+        }
+    }
+    </script>
+</head>
+<body>
+    <div id="app"></div>
+    <script type="module" src="/js/preview.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/styles.css
+++ b/src/main/resources/static/styles.css
@@ -1,75 +1,918 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f8fb;
+  --surface: #ffffff;
+  --surface-muted: #f3f6fa;
+  --surface-strong: #edf2f7;
+  --text: #172033;
+  --text-muted: #5f6b7a;
+  --text-soft: #8a96a6;
+  --border: #dde4ee;
+  --border-strong: #c8d2df;
+  --accent: #2563eb;
+  --accent-soft: #eaf1ff;
+  --accent-strong: #1d4ed8;
+  --success: #11845b;
+  --success-soft: #e7f6ef;
+  --warning: #a16207;
+  --warning-soft: #fff7df;
+  --danger: #c2413a;
+  --danger-soft: #fff0ef;
+  --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.04);
+  --shadow-md: 0 16px 40px rgba(16, 24, 40, 0.08);
+  --radius: 8px;
+  --radius-sm: 6px;
+}
+
 * {
   box-sizing: border-box;
 }
 
-body {
-  margin: 0;
-  padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background: #ecf0f1;
+html {
+  background: var(--bg);
 }
 
-#app {
+body {
+  margin: 0;
+  min-width: 320px;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top left, rgba(37, 99, 235, 0.06), transparent 30rem),
+    var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+a {
+  transition:
+    background-color 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease,
+    color 0.16s ease,
+    transform 0.16s ease;
+}
+
+button {
+  appearance: none;
+}
+
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.22);
+  outline-offset: 2px;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+#app,
+.app-shell {
   min-height: 100vh;
 }
 
-/* Scrollbar styling */
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;
 }
 
 ::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--surface-muted);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #888;
-  border-radius: 5px;
+  background: #c7d0dc;
+  border: 2px solid var(--surface-muted);
+  border-radius: 999px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: #9ba8b8;
 }
 
-/* Button focus styles */
-button:focus {
-  outline: 2px solid #3498db;
-  outline-offset: 2px;
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem clamp(1rem, 4vw, 2rem);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.86);
+  border-bottom: 1px solid rgba(221, 228, 238, 0.78);
+  backdrop-filter: blur(16px);
 }
 
-/* Input focus styles */
-input:focus,
-textarea:focus {
-  outline: 2px solid #3498db;
-  outline-offset: 0;
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  min-width: 0;
 }
 
-/* Smooth transitions */
-button,
-a {
-  transition: all 0.2s ease;
+.brand-mark {
+  display: grid;
+  width: 2.25rem;
+  height: 2.25rem;
+  place-items: center;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2563eb, #14b8a6);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 20px rgba(37, 99, 235, 0.18);
+  font-size: 0.95rem;
+  font-weight: 800;
 }
 
-/* Responsive images */
-img {
-  max-width: 100%;
-  height: auto;
+.brand-title {
+  margin: 0;
+  overflow: hidden;
+  font-size: 1rem;
+  font-weight: 750;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-/* Mobile responsiveness */
-@media (max-width: 768px) {
-  header {
-    flex-direction: column !important;
-    gap: 1rem !important;
+.top-nav {
+  display: inline-flex;
+  gap: 0.25rem;
+  justify-content: center;
+  padding: 0.25rem;
+  background: var(--surface-muted);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.nav-button {
+  min-height: 2.25rem;
+  padding: 0 0.8rem;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-weight: 650;
+}
+
+.nav-button:hover {
+  color: var(--text);
+  background: #ffffff;
+}
+
+.nav-button.active {
+  color: var(--text);
+  background: #ffffff;
+  border-color: var(--border);
+  box-shadow: var(--shadow-sm);
+}
+
+.nav-button.admin.active {
+  color: var(--danger);
+  border-color: rgba(194, 65, 58, 0.2);
+}
+
+.user-menu {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.user-identity {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.avatar {
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+.logout-link,
+.text-link {
+  color: var(--text-muted);
+  text-decoration: none;
+  font-weight: 650;
+}
+
+.logout-link:hover,
+.text-link:hover {
+  color: var(--accent);
+}
+
+.page {
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.page.wide {
+  width: min(1320px, 100%);
+}
+
+.page-header,
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.page-title,
+.section-title {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.15;
+}
+
+.page-title {
+  font-size: clamp(1.55rem, 4vw, 2.2rem);
+  font-weight: 760;
+}
+
+.section-title {
+  font-size: 1.05rem;
+  font-weight: 730;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.soft {
+  color: var(--text-soft);
+}
+
+.toolbar {
+  display: flex;
+  align-items: stretch;
+  gap: 0.6rem;
+}
+
+.search-shell {
+  margin-bottom: 1.25rem;
+}
+
+.search-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 0.6rem;
+}
+
+.filters-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.input,
+.select {
+  width: 100%;
+  min-height: 2.65rem;
+  padding: 0.65rem 0.8rem;
+  color: var(--text);
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.input::placeholder {
+  color: var(--text-soft);
+}
+
+.input:hover,
+.select:hover {
+  border-color: var(--border-strong);
+}
+
+.button {
+  display: inline-flex;
+  min-height: 2.65rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.6rem 0.95rem;
+  color: var(--text);
+  background: #ffffff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.button:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.button.primary {
+  color: #ffffff;
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+}
+
+.button.primary:hover:not(:disabled) {
+  background: var(--accent-strong);
+  border-color: var(--accent-strong);
+}
+
+.button.success {
+  color: #ffffff;
+  background: var(--success);
+  border-color: var(--success);
+}
+
+.button.danger {
+  color: #ffffff;
+  background: var(--danger);
+  border-color: var(--danger);
+}
+
+.button.ghost {
+  color: var(--text-muted);
+  background: transparent;
+  box-shadow: none;
+}
+
+.button.full {
+  width: 100%;
+}
+
+.button.compact {
+  min-height: 2.25rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+}
+
+.panel {
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.panel + .panel,
+.section + .section {
+  margin-top: 1.25rem;
+}
+
+.panel.running {
+  border-color: rgba(37, 99, 235, 0.45);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.08);
+}
+
+.panel .section-title {
+  margin-bottom: 0.75rem;
+}
+
+.book-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.book-card {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.7rem;
+  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+  cursor: pointer;
+}
+
+.book-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 12px 26px rgba(16, 24, 40, 0.08);
+  transform: translateY(-2px);
+}
+
+.book-card:focus-visible {
+  outline: 3px solid rgba(37, 99, 235, 0.22);
+  outline-offset: 3px;
+}
+
+.book-cover {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  overflow: hidden;
+  background: var(--surface-strong);
+  border-radius: var(--radius-sm);
+}
+
+.book-cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.book-cover-placeholder {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  place-items: center;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.book-cover-placeholder.large {
+  aspect-ratio: 3 / 4;
+}
+
+.book-card-body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+}
+
+.book-title {
+  margin: 0 0 0.35rem;
+  color: var(--text);
+  font-size: 0.98rem;
+  font-weight: 740;
+  line-height: 1.35;
+}
+
+.book-meta {
+  margin: 0 0 0.25rem;
+  color: var(--text-muted);
+  font-size: 0.86rem;
+  line-height: 1.35;
+}
+
+.book-series {
+  margin: 0;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.7rem;
+}
+
+.chip,
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.7rem;
+  padding: 0.25rem 0.55rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.chip {
+  color: #405066;
+  background: var(--surface-muted);
+  border-color: rgba(221, 228, 238, 0.8);
+}
+
+.chip.accent {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+.status-badge {
+  color: var(--accent-strong);
+  background: var(--accent-soft);
+}
+
+.status-badge.success {
+  color: var(--success);
+  background: var(--success-soft);
+}
+
+.status-badge.warning {
+  color: var(--warning);
+  background: var(--warning-soft);
+}
+
+.status-badge.danger {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.empty-state,
+.loading-state {
+  padding: 2.5rem 1rem;
+  color: var(--text-soft);
+  text-align: center;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.range-label {
+  min-width: 8rem;
+  color: var(--text-muted);
+  font-size: 0.92rem;
+  text-align: center;
+}
+
+.detail-layout {
+  display: grid;
+  grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+  gap: clamp(1.2rem, 4vw, 2.5rem);
+  align-items: start;
+}
+
+.detail-cover {
+  overflow: hidden;
+  background: var(--surface-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.detail-cover img {
+  display: block;
+  width: 100%;
+}
+
+.action-stack {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.side-actions {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.detail-title {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 4vw, 2.8rem);
+  font-weight: 780;
+  line-height: 1.08;
+}
+
+.detail-author {
+  margin: 0 0 1rem;
+  color: var(--text-muted);
+  font-size: 1.08rem;
+  line-height: 1.5;
+}
+
+.annotation {
+  margin-top: 1rem;
+  padding: 1rem;
+  color: #2c3748;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  line-height: 1.65;
+  white-space: pre-wrap;
+}
+
+.list-stack {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.list-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.list-item-main {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.item-title {
+  color: var(--text);
+  font-weight: 740;
+}
+
+.item-subtitle {
+  margin-top: 0.18rem;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.item-note {
+  margin-top: 0.18rem;
+  color: var(--text-soft);
+  font-size: 0.76rem;
+}
+
+.form-panel {
+  display: grid;
+  gap: 0.6rem;
+  margin-bottom: 1rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.form-actions.center {
+  justify-content: center;
+}
+
+.history-row {
+  display: block;
+}
+
+.history-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.error-text {
+  margin-top: 0.5rem;
+  color: var(--danger);
+  font-size: 0.78rem;
+}
+
+.job-log {
+  max-height: 300px;
+  margin: 1rem 0;
+  overflow-y: auto;
+  background: #fbfcfe;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.job-log-title {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 0.55rem 0.8rem;
+  color: var(--text-muted);
+  background: #ffffff;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82rem;
+  font-weight: 740;
+}
+
+.job-log-body {
+  padding: 0.45rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.76rem;
+}
+
+.job-log-row {
+  display: flex;
+  gap: 0.75rem;
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid var(--surface-strong);
+}
+
+.job-log-time {
+  flex: 0 0 auto;
+  color: var(--text-soft);
+  white-space: nowrap;
+}
+
+.job-log-message {
+  color: #405066;
+  word-break: break-word;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.65rem;
+}
+
+.metric {
+  padding: 0.75rem;
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+}
+
+.metric-label {
+  color: var(--text-soft);
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.metric-value {
+  margin-top: 0.2rem;
+  color: var(--text);
+  font-size: 1.2rem;
+  font-weight: 780;
+}
+
+.danger-text {
+  color: var(--danger);
+}
+
+.completed-note {
+  margin-top: 0.75rem;
+}
+
+.auth-page {
+  display: grid;
+  min-height: 100vh;
+  place-items: center;
+  padding: 1.5rem;
+  background:
+    radial-gradient(circle at 20% 10%, rgba(20, 184, 166, 0.12), transparent 18rem),
+    radial-gradient(circle at 80% 0%, rgba(37, 99, 235, 0.12), transparent 22rem),
+    var(--bg);
+}
+
+.auth-card,
+.error-card {
+  width: min(100%, 420px);
+  padding: clamp(1.4rem, 5vw, 2rem);
+  text-align: center;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+}
+
+.auth-mark,
+.error-mark {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  margin: 0 auto 1rem;
+  place-items: center;
+  color: #ffffff;
+  background: linear-gradient(135deg, #2563eb, #14b8a6);
+  border-radius: var(--radius);
+  font-size: 1.15rem;
+  font-weight: 800;
+}
+
+.error-mark {
+  color: var(--danger);
+  background: var(--danger-soft);
+}
+
+.auth-title,
+.error-title {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  font-weight: 780;
+  line-height: 1.1;
+}
+
+.auth-copy,
+.error-copy {
+  margin: 0 0 1.5rem;
+  color: var(--text-muted);
+  line-height: 1.55;
+}
+
+.error-details {
+  margin: 0 0 1.25rem;
+  padding: 0.85rem;
+  color: var(--danger);
+  background: var(--danger-soft);
+  border: 1px solid rgba(194, 65, 58, 0.16);
+  border-radius: var(--radius);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  text-align: left;
+  word-break: break-word;
+}
+
+.auth-footnote {
+  margin: 1.25rem 0 0;
+  color: var(--text-soft);
+  font-size: 0.78rem;
+}
+
+@media (max-width: 820px) {
+  .site-header {
+    grid-template-columns: 1fr;
+    justify-items: stretch;
   }
 
-  nav {
-    flex-wrap: wrap !important;
-    justify-content: center !important;
+  .top-nav,
+  .user-menu {
+    justify-content: flex-start;
+  }
+
+  .top-nav {
+    overflow-x: auto;
+  }
+
+  .search-form,
+  .detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-cover {
+    max-width: 280px;
+  }
+
+  .page-header,
+  .section-header,
+  .history-topline,
+  .list-item {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .toolbar {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 520px) {
+  .page {
+    padding: 1rem;
+  }
+
+  .book-grid {
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  }
+
+  .pagination {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .range-label {
+    min-width: 0;
+  }
+
+  .button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary

Applies the missing static UI refresh so the Preact components use the stylesheet instead of inline style objects.

## Details

The refreshed CSS already existed on the backup UI branch, but the active components did not reference the matching classes. This PR moves the static frontend to `className`-based styling, expands `styles.css` with shared UI tokens and component styles, and adds a static preview page for quick visual QA.

## Impact

The app now renders the refreshed styles through the linked stylesheet. `/preview.html` can be served locally from the static directory to inspect the styled books, detail, Kindle, and admin views without logging in.

## Validation

- `git diff --check origin/main..HEAD`
- `rg --files src/main/resources/static/js | xargs -n1 node --check`
- Fetched `http://127.0.0.1:8091/preview.html` from a local static server
