### PR TITLE
Fix correctness & security findings from #100 review

### DIFF
--- a/src/main/kotlin/io/heapy/kotbusta/parser/InpxParser.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/parser/InpxParser.kt
@@ -88,6 +88,7 @@ class InpxParser(
                 stats.addMessage("Found ${entries.size} .inp files to process")
 
                 entries.forEachIndexed { index, entry ->
+                    stats.resetSequentialBookErrors()
                     stats.setCurrentInpFile(entry.name)
                     val archiveName = entry.name.removeSuffix(".inp")
                     val books = zipFile.getInputStream(entry)

--- a/src/main/kotlin/io/heapy/kotbusta/service/BookFileService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/BookFileService.kt
@@ -96,7 +96,18 @@ class ZipBookFileService(
             .replace(UNDERSCORES, "_")
             .trim('.', '_')
             .ifBlank { "book_${book.id}" }
-            .take(100)
+            .truncateForFilename()
+
+    private fun String.truncateForFilename(): String {
+        val truncated = take(100)
+        val withoutTrailingHighSurrogate = if (truncated.lastOrNull()?.isHighSurrogate() == true) {
+            truncated.dropLast(1)
+        } else {
+            truncated
+        }
+
+        return withoutTrailingHighSurrogate.trimEnd('.', '_')
+    }
 
     private companion object : Logger() {
         private val UNSAFE_FILENAME_CHARS = Regex("""[\p{Cntrl}/\\:*?"<>|]+""")

--- a/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
@@ -123,8 +123,8 @@ internal fun buildRawEmail(
     // filename= when both are present, which would replace the real title
     // with the ASCII fallback; extended-only is what calibre sends to
     // Kindle and is known to decode correctly there.
-    val disposition = if (fallbackName == attachmentName) {
-        """attachment; filename="$fallbackName""""
+    val disposition = if (attachmentName.all { it.code in 0x20..0x7E }) {
+        """attachment; filename="$attachmentName""""
     } else {
         "attachment; filename*=${rfc2231FileName(attachmentName)}"
     }

--- a/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
@@ -125,6 +125,9 @@ internal fun buildRawEmail(
     attachmentName: String,
     mimeType: String,
 ): ByteArray {
+    require(to.none { it.isISOControl() }) { "recipient address must not contain CR or LF" }
+    require(from.none { it.isISOControl() }) { "sender address must not contain CR or LF" }
+
     val boundary = "----=_Part_${System.currentTimeMillis()}"
     val fallbackName = asciiFallbackFileName(attachmentName)
     // For non-ASCII names send ONLY the RFC 2231 filename*. Common parsers

--- a/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/EmailService.kt
@@ -99,12 +99,21 @@ class SesEmailService(
 
 private val CONTROL_OR_QUOTE = Regex("""[\p{Cntrl}"]+""")
 private val WHITESPACE = Regex("""\s+""")
+private const val MAX_SANITIZED_BOOK_TITLE_LENGTH = 100
 
 internal fun sanitizeBookTitle(title: String): String =
     title
         .replace(CONTROL_OR_QUOTE, " ")
         .replace(WHITESPACE, " ")
         .trim()
+        .let { sanitizedTitle ->
+            val truncated = sanitizedTitle.take(MAX_SANITIZED_BOOK_TITLE_LENGTH)
+            if (truncated.lastOrNull()?.let { Character.isHighSurrogate(it) } == true) {
+                truncated.dropLast(1)
+            } else {
+                truncated
+            }.trim()
+        }
         .ifBlank { "book" }
 
 internal fun buildRawEmail(

--- a/src/main/kotlin/io/heapy/kotbusta/service/KindleService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/KindleService.kt
@@ -52,7 +52,7 @@ class KindleService(
     context(_: TransactionContext, userSession: UserSession)
     fun createDevice(request: CreateDeviceRequest): DeviceResponse {
         // Validate email format
-        if (!request.email.endsWith("@kindle.com", ignoreCase = true)) {
+        if (!isValidKindleEmail(request.email)) {
             throw IllegalArgumentException("Email must be a valid Kindle email address (ending with @kindle.com)")
         }
 
@@ -216,5 +216,10 @@ class KindleService(
 
     private companion object : Logger()
 }
+
+internal fun isValidKindleEmail(email: String): Boolean =
+    email.isNotBlank() &&
+        email.none { it.isISOControl() || it.isWhitespace() } &&
+        email.endsWith("@kindle.com", ignoreCase = true)
 
 class QuotaExceededException(message: String) : Exception(message)

--- a/src/test/kotlin/io/heapy/kotbusta/parser/InpxParserTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/parser/InpxParserTest.kt
@@ -167,6 +167,30 @@ class InpxParserTest {
         assertEquals(0, stagingTableCount(tx))
     }
 
+    @Test
+    fun `sequential invalid book streak resets between inp files`(
+        applicationModule: ApplicationModule,
+    ) = runBlocking {
+        val tx = applicationModule.transactionProvider.value
+        val parser = applicationModule.inpxParser.value
+        val booksDir = Files.createTempDirectory("inpx-test-")
+        val invalidLines = List(60) { "not enough fields" }
+
+        writeRawInpxEntries(
+            booksDir,
+            listOf(
+                "a-first.inp" to listOf(rawBookLine(book(9001, "Alpha"))) + invalidLines,
+                "b-second.inp" to invalidLines + listOf(rawBookLine(book(9002, "Beta"))),
+            ),
+        )
+
+        parser.parseAndImport(booksDir, ImportStats())
+
+        assertEquals(2, countSynthetic(tx))
+        assertEquals(listOf("Alpha", "Beta"), syntheticTitles(tx))
+        assertEquals(0, stagingTableCount(tx))
+    }
+
     private data class InpBook(
         val id: Int,
         val title: String,
@@ -192,32 +216,31 @@ class InpxParserTest {
     }
 
     private fun writeInpxEntries(dir: Path, entries: List<Pair<String, List<InpBook>>>) {
-        val sep = ''
         val inpxFile = dir.resolve("flibusta_fb2_local.inpx").toFile()
         ZipOutputStream(inpxFile.outputStream()).use { zip ->
             entries.forEach { (entryName, books) ->
-                val lines = books.joinToString("\n") { b ->
-                    listOf(
-                        b.author,
-                        b.genre,
-                        b.title,
-                        "",
-                        "",
-                        b.id.toString(),
-                        "1024",
-                        b.id.toString(),
-                        if (b.deleted) "1" else "0",
-                        "fb2",
-                        "2024-01-01",
-                        "ru",
-                    ).joinToString(sep.toString())
-                }
+                val lines = books.joinToString("\n", transform = ::rawBookLine)
                 zip.putNextEntry(ZipEntry(entryName))
                 zip.write(lines.toByteArray(Charsets.UTF_8))
                 zip.closeEntry()
             }
         }
     }
+
+    private fun rawBookLine(b: InpBook): String = listOf(
+        b.author,
+        b.genre,
+        b.title,
+        "",
+        "",
+        b.id.toString(),
+        "1024",
+        b.id.toString(),
+        if (b.deleted) "1" else "0",
+        "fb2",
+        "2024-01-01",
+        "ru",
+    ).joinToString("\u0004")
 
     private fun writeRawInpxEntries(dir: Path, entries: List<Pair<String, List<String>>>) {
         val inpxFile = dir.resolve("flibusta_fb2_local.inpx").toFile()

--- a/src/test/kotlin/io/heapy/kotbusta/service/BookFileServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/BookFileServiceTest.kt
@@ -74,6 +74,26 @@ class BookFileServiceTest {
     }
 
     @Test
+    fun `materialize does not split astral character in truncated download filename`() = runBlocking {
+        writeArchive(archivePath = "fb2-001", entryName = "42.fb2", content = "<fb2>raw</fb2>")
+        val service = ZipBookFileService(booksDataPath, RecordingConversionService())
+        val title = "A".repeat(99) + "🎉"
+
+        val materialized = service.materialize(book(title = title), "fb2")
+
+        try {
+            assertEquals(
+                materialized.fileName,
+                String(materialized.fileName.toByteArray(Charsets.UTF_8), Charsets.UTF_8),
+            )
+            assertFalse(materialized.fileName.removeSuffix(".fb2").endsWith('.'))
+            assertFalse(materialized.fileName.removeSuffix(".fb2").endsWith('_'))
+        } finally {
+            materialized.cleanup()
+        }
+    }
+
+    @Test
     fun `materialize fails when archive entry is missing`() {
         writeArchive(archivePath = "fb2-001", entryName = "other.fb2", content = "other")
         val service = ZipBookFileService(booksDataPath, RecordingConversionService())

--- a/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
@@ -2,6 +2,7 @@ package io.heapy.kotbusta.service
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.Base64
@@ -170,6 +171,21 @@ class EmailServiceTest {
 
         assertFalse(raw.lines().any { it.startsWith("Bcc:") }, "injected header must not appear")
         assertTrue(raw.contains("Subject: Your book: Evil Bcc: evil@example.com\r\n"))
+    }
+
+    @Test
+    fun `recipient with crlf is rejected to prevent header injection`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            buildRawEmail(
+                from = "sender@example.com",
+                to = "device@kindle.com\r\nBcc: evil@example.com",
+                subject = "Your book: X",
+                body = "b",
+                attachmentBytes = byteArrayOf(1, 2, 3),
+                attachmentName = "X.epub",
+                mimeType = "application/epub+zip",
+            )
+        }
     }
 
     @Test

--- a/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
@@ -74,6 +74,17 @@ class EmailServiceTest {
     }
 
     @Test
+    fun `ascii attachment filename with spaces is sent as plain quoted filename`() {
+        val raw = rawEmail(
+            subject = "Your book: War and Peace",
+            attachmentName = "War and Peace.epub",
+        )
+
+        assertTrue(raw.contains("Content-Disposition: attachment; filename=\"War and Peace.epub\""))
+        assertFalse(raw.contains("filename*"))
+    }
+
+    @Test
     fun `lines end with crlf`() {
         val raw = rawEmail(
             subject = "Your book: Clean_Title",

--- a/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/EmailServiceTest.kt
@@ -18,6 +18,15 @@ class EmailServiceTest {
             mimeType = "application/epub+zip",
         ).toString(Charsets.ISO_8859_1)
 
+    private fun assertAllHeaderLinesWithinRfc5322(raw: String) {
+        raw.split("\r\n").forEach { line ->
+            assertTrue(
+                line.toByteArray(Charsets.ISO_8859_1).size <= 998,
+                "line exceeds RFC 5322 998-octet limit (${line.length} chars): ${line.take(80)}...",
+            )
+        }
+    }
+
     @Test
     fun `headers are pure ascii for cyrillic titles`() {
         val raw = rawEmail(
@@ -82,6 +91,30 @@ class EmailServiceTest {
 
         assertTrue(raw.contains("Content-Disposition: attachment; filename=\"War and Peace.epub\""))
         assertFalse(raw.contains("filename*"))
+    }
+
+    @Test
+    fun `sanitized cyrillic title keeps raw message lines within rfc5322 limit`() {
+        val longCyrillic = "Медитація".repeat(40)
+        val title = sanitizeBookTitle(longCyrillic)
+        val raw = rawEmail(
+            subject = "Your book: $title",
+            attachmentName = "$title.epub",
+        )
+
+        assertAllHeaderLinesWithinRfc5322(raw)
+    }
+
+    @Test
+    fun `sanitized ascii title keeps raw message lines within rfc5322 limit`() {
+        val longAscii = "War and Peace ".repeat(120)
+        val title = sanitizeBookTitle(longAscii)
+        val raw = rawEmail(
+            subject = "Your book: $title",
+            attachmentName = "$title.epub",
+        )
+
+        assertAllHeaderLinesWithinRfc5322(raw)
     }
 
     @Test

--- a/src/test/kotlin/io/heapy/kotbusta/service/KindleServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/KindleServiceTest.kt
@@ -1,0 +1,22 @@
+package io.heapy.kotbusta.service
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class KindleServiceTest {
+    @Test
+    fun `valid kindle email is accepted`() {
+        assertTrue(isValidKindleEmail("device@kindle.com"))
+    }
+
+    @Test
+    fun `crlf header injection payload is rejected`() {
+        assertFalse(isValidKindleEmail("me@evil.com\r\nBcc: x@kindle.com"))
+    }
+
+    @Test
+    fun `non kindle email is rejected`() {
+        assertFalse(isValidKindleEmail("me@gmail.com"))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes five correctness/security findings from a code review of #100 (book-delivery / mojibake work). Each fix was developed test-first: a red test reproducing the bug, the minimal fix, then a green test. Red-before-fix was independently re-verified for every finding. The full `:test` suite passes.

## Findings fixed

1. **Cross-file error streak aborted healthy imports** — `InpxParser`
   The "abort after 100 sequential invalid book records" counter was only reset on a successful/deleted record, never at `.inp` file boundaries. A streak spanning the end of one archive file and the start of the next was summed and could abort an otherwise-healthy import (dropping all staged data) even though no single file had 100 consecutive bad records. Now reset at each file boundary.

2. **Download filenames could be truncated mid-code-point** — `BookFileService`
   `sanitizedTitle` ended with `take(100)`, which counts UTF-16 units and could split a surrogate pair for a title with a non-BMP character near the 100-char boundary, leaving a lone surrogate that became `U+FFFD` (`%EF%BF%BD`) once the filename was percent-encoded. Truncation is now code-point safe.

3. **Long titles produced illegal (>998-octet) header lines** — `EmailService`
   `sanitizeBookTitle` had no length cap, so a long INPX title yielded an un-folded `Subject:` or `Content-Disposition` `filename*` line exceeding RFC 5322's 998-octet limit, which SES rejects. The sanitized title is now capped at 100 code points (consistent with the download path).

4. **ASCII titles with spaces lost their plain `filename=`** — `EmailService`
   `buildRawEmail` sent extended-only `filename*` whenever the ASCII fallback differed from the name, which also fires for pure-ASCII titles with spaces (e.g. "War and Peace"), leaving clients without RFC 2231 support with no filename at all. The extended-only branch is now gated on the name actually being non-ASCII; ASCII names get a plain quoted `filename=` that works everywhere.

5. **Email header injection via the Kindle recipient address** — `EmailService` + `KindleService`
   `buildRawEmail` wrote the recipient into the `To:` header verbatim while `createDevice` validated it only with `endsWith("@kindle.com")`, so an address containing CR/LF passed validation and injected headers (`Bcc`, `Reply-To`) into the raw SES message. `buildRawEmail` now fails closed on any control character in the `to`/`from` addresses, and the Kindle email validation (extracted `isValidKindleEmail`) rejects control characters and whitespace.

## Tests

- New: cross-file streak reset (`InpxParserTest`), astral-character truncation (`BookFileServiceTest`), ASCII-filename-with-spaces, RFC 5322 line-length for Cyrillic + ASCII titles, CRLF recipient rejection (`EmailServiceTest`), and `isValidKindleEmail` cases (`KindleServiceTest`).
- All pre-existing tests remain green; full `./gradlew :test` passes.

## Not included (deferred cleanup)

The review also raised non-bug cleanup items that this PR intentionally leaves out to keep it focused and low-risk. Worth a follow-up:
- Consolidate the three overlapping filename/title sanitizers (`BookFileService.sanitizedTitle`, `EmailService.sanitizeBookTitle`, `util.asciiFallbackFileName`) and have the Kindle path reuse `MaterializedBook.fileName` instead of re-deriving it (single source of truth for a book's delivered filename).
- `buildRawEmail` holds the attachment ~4–5× in memory (raw bytes + base64 String + StringBuilder + final `toByteArray`); stream via `Base64.getMimeEncoder().wrap(...)`.
- `AutoTokenTypeTextEmbeddingTranslator` eagerly builds both translator variants but uses one; build the single needed delegate in `prepare()`.
- `rfc2231FileName` / disposition branching duplicate Ktor's `ContentDisposition` and the new `downloadContentDisposition`.
- `ImportJob.maxSequentialBookErrors` serializes a compile-time constant that the frontend also hardcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
