### PR TITLE
Delete Lucene index backup only after the old reader is closed

### DIFF
--- a/src/main/kotlin/io/heapy/kotbusta/service/LuceneBookSearchService.kt
+++ b/src/main/kotlin/io/heapy/kotbusta/service/LuceneBookSearchService.kt
@@ -275,12 +275,28 @@ class LuceneBookSearchService(
 
         try {
             val indexedBooks = buildIndex(tempIndexPath)
-            swapIndexFiles(tempIndexPath)
+            val backupPath = swapIndexFiles(tempIndexPath)
 
             val newIndex = loadIndexIfCurrent(indexPath)
                 ?: throw IllegalStateException("Lucene index build completed without a readable commit")
 
             installActiveIndex(newIndex)
+
+            // Delete the previous index only after installActiveIndex has closed the
+            // old reader, releasing its file handles. On filesystems with
+            // delete-on-last-close semantics (NFS silly-rename, some CIFS/FUSE-backed
+            // volumes) unlinking files that are still mmap'd by the live reader leaves
+            // hidden placeholder entries behind, which makes the recursive delete fail
+            // with DirectoryNotEmptyException. A stale backup is harmless: it is
+            // cleared at the start of the next swap.
+            backupPath?.let { path ->
+                try {
+                    path.deleteRecursivelyIfExists()
+                } catch (e: Exception) {
+                    log.warn("Failed to delete previous Lucene index backup at $path", e)
+                }
+            }
+
             state.set(SearchIndexState.READY)
             log.info("Lucene search index rebuilt with $indexedBooks books")
         } catch (e: Exception) {
@@ -338,8 +354,18 @@ class LuceneBookSearchService(
         total
     }
 
-    private fun swapIndexFiles(tempIndexPath: Path) {
+    /**
+     * Moves the freshly built index at [tempIndexPath] into place, preserving the
+     * previous index directory as a sibling `-backup`. Returns the backup path when a
+     * previous index was displaced (so the caller can delete it once its reader is
+     * closed), or null when there was no previous index. The old index files are
+     * intentionally NOT deleted here: the live reader still has them open at this
+     * point, so deleting them is unsafe on filesystems without unlink-on-open support.
+     */
+    private fun swapIndexFiles(tempIndexPath: Path): Path? {
         val backupPath = indexPath.resolveSibling("${indexPath.name}-backup")
+        // Clear any leftover backup from a previous crash before we move onto it; no
+        // reader is open on it at this point, so the delete is safe here.
         backupPath.deleteRecursivelyIfExists()
 
         val hadPrevious = Files.exists(indexPath)
@@ -356,7 +382,7 @@ class LuceneBookSearchService(
             throw e
         }
 
-        backupPath.deleteRecursivelyIfExists()
+        return if (hadPrevious) backupPath else null
     }
 
     private fun buildLuceneQuery(query: SearchQuery): Query {

--- a/src/test/kotlin/io/heapy/kotbusta/service/LuceneBookSearchServiceTest.kt
+++ b/src/test/kotlin/io/heapy/kotbusta/service/LuceneBookSearchServiceTest.kt
@@ -48,6 +48,35 @@ class LuceneBookSearchServiceTest {
     }
 
     @Test
+    fun `rebuild deletes the previous index backup and keeps serving`(
+        applicationModule: ApplicationModule,
+    ) = runBlocking {
+        addBulkSearchFixtures(applicationModule, bookCount = 5)
+
+        val indexPath = Files.createTempDirectory("test-kotbusta-lucene-swap-")
+        val service = LuceneBookSearchService(
+            transactionProvider = applicationModule.transactionProvider.value,
+            indexPath = indexPath,
+        )
+        val backupPath = indexPath.resolveSibling("${indexPath.fileName}-backup")
+
+        try {
+            service.rebuildNow()
+            assertTrue(service.search(SearchQuery(query = "bulk", limit = 10)).total > 0)
+
+            // The second rebuild displaces the first index while its reader is still
+            // open. The backup must be removed once the new reader is installed and
+            // must not linger, and the service must keep returning results.
+            service.rebuildNow()
+
+            assertEquals(false, Files.exists(backupPath))
+            assertEquals(5L, service.search(SearchQuery(query = "bulk", limit = 10)).total)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
     fun `semantic search ranks books by stored embeddings`(
         applicationModule: ApplicationModule,
     ) = runBlocking {


### PR DESCRIPTION
## Problem

The on-startup / scheduled Lucene index rebuild intermittently fails with:

```
ERROR i.h.k.s.LuceneBookSearchService -- Failed to rebuild Lucene search index
java.nio.file.DirectoryNotEmptyException: /data/db/lucene-backup
    at ...LuceneBookSearchService.swapIndexFiles(LuceneBookSearchService.kt:359)
```

leaving the index in the `FAILED` state.

## Root cause

`swapIndexFiles` performed the whole swap **and** the backup cleanup:

1. `Files.move(indexPath → <name>-backup)` — moves the **live** index directory (still open and serving searches) to the backup path. Same-filesystem move is a rename, so the reader's file descriptors stay valid.
2. `Files.move(temp → indexPath)` — moves the freshly built index into place.
3. `backupPath.deleteRecursivelyIfExists()` — deletes the old index files **while the previous reader still has them mmapped**.

`installActiveIndex`, which closes the old reader and releases those handles, only runs *after* `swapIndexFiles` returns — too late.

On a local filesystem, unlinking an open file removes its directory entry immediately, so this works. On a mounted volume with **delete-on-last-close semantics** (NFS silly-rename, some CIFS/FUSE-backed Docker volumes — which `/data/db` is), the still-open files get renamed to hidden placeholder entries instead. The recursive delete then reaches the now-non-empty directory node and throws `DirectoryNotEmptyException`.

The timing in the logs matches: server up, then ~10s later the initial post-startup rebuild (which had loaded the existing on-disk index, so a reader was open during the swap) fails.

## Fix

- `swapIndexFiles` now performs only the moves and **returns** the backup path (or `null` when there was no previous index).
- `rebuildIndexOnce` deletes the backup **after** `installActiveIndex` has closed the old reader and released its handles — enforcing the invariant *"never unlink index files while a reader has them mapped,"* which holds on any filesystem.
- Cleanup failures are logged, not fatal — a stale backup is harmless and is cleared at the start of the next swap (that delete happens when no reader is open on it).

## Testing

- Added `rebuild deletes the previous index backup and keeps serving` — rebuilds twice (the second displaces a still-open index) and asserts the `-backup` directory is gone and search still returns results.
- `./gradlew :test --tests "io.heapy.kotbusta.service.LuceneBookSearchServiceTest"` → 5 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)