### PR TITLE
Use persistent BuildKit for Kotbusta CI

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -4,10 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Docker image tag"
+        description: Docker image tag
         required: true
-        default: "latest"
+        default: latest
         type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kotbusta-docker-publish
+  cancel-in-progress: false
 
 env:
   REGISTRY: ghcr.io
@@ -15,7 +22,12 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - docker-builder
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -24,8 +36,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Docker Buildx
+      - name: Verify runner cache infrastructure
+        run: /usr/local/libexec/heapy-runner-cache/cache-health.sh --quick
+
+      - name: Use persistent Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
+        with:
+          name: heapy-ci
+          driver: docker-container
+          cleanup: false
+          cache-binary: false
 
       - name: Log in to the Container registry
         uses: docker/login-action@v4
@@ -46,11 +67,10 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Base.Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,60 +1,109 @@
-name: "Build Kotbusta Docker"
+name: Build Kotbusta
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions:
   contents: read
 
-on:
-  - push
-  - pull_request
+concurrency:
+  group: kotbusta-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: "Build Application"
-    runs-on: self-hosted
+  pull-request:
+    name: Verify pull request
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - kotbusta-ci
+    timeout-minutes: 15
+
     steps:
       - uses: actions/checkout@v7
+
       - uses: actions/setup-java@v5
         with:
           java-version: "25"
-          distribution: "liberica"
-      - name: "Unpack test data"
+          distribution: liberica
+          check-latest: false
+
+      - name: Unpack test data
         run: src/test/resources/unpack-flibusta-sample.sh
-      - name: "Run tests"
+
+      - name: Run tests
         run: ./kotlin test
-      - name: "Build distribution"
-        run: ./kotlin do distTar -m kotbusta
-      - uses: actions/upload-artifact@v7
-        with:
-          name: "Kotlin Application"
-          path: "build/distributions/kotbusta.tar"
-          retention-days: 1
-  build-and-push-image:
-    name: "Build Docker Image"
-    if: ${{ github.ref == 'refs/heads/main' }}
-    runs-on: self-hosted
+
+      - name: Build distribution
+        run: ./kotlin "do" distTar -m kotbusta
+
+  main:
+    name: Build and publish Docker image
+    if: github.event_name == 'push'
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - docker-builder
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write
-    needs: build
+
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/download-artifact@v8
+
+      - uses: actions/setup-java@v5
         with:
-          name: "Kotlin Application"
-          path: "build/distributions/"
-      - name: "Untar files"
-        run: mkdir -p build/install && tar -xvf build/distributions/kotbusta.tar -C $_
-      - name: "Set up Docker Buildx"
+          java-version: "25"
+          distribution: liberica
+          check-latest: false
+
+      - name: Unpack test data
+        run: src/test/resources/unpack-flibusta-sample.sh
+
+      - name: Run tests
+        run: ./kotlin test
+
+      - name: Build distribution
+        run: ./kotlin "do" distTar -m kotbusta
+
+      - name: Prepare Docker context
+        run: |
+          set -euo pipefail
+          install -d build/install
+          tar -xf build/distributions/kotbusta.tar -C build/install
+
+      - name: Verify runner cache infrastructure
+        run: /usr/local/libexec/heapy-runner-cache/cache-health.sh --quick
+
+      - name: Use persistent Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v4
-      - name: "Login to GHCR"
+        with:
+          name: heapy-ci
+          driver: docker-container
+          cleanup: false
+          cache-binary: false
+
+      - name: Login to GHCR
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password:  ${{ secrets.GITHUB_TOKEN }}
-      - name: "Build and push"
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
         uses: docker/build-push-action@v7
         with:
+          builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64
           context: .
           push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,9 @@
 # Build manually with GitHub Actions: ghcr.io/heapy/kotbusta-base:latest
 FROM ghcr.io/heapy/kotbusta-base:latest
 
-# Switch back to root temporarily to copy and set permissions
-USER root
+# Copy the application with its final ownership in one layer.
+COPY --chown=kotbusta:kotbusta /build/install/kotbusta /kotbusta
 
-# Copy the application
-COPY /build/install/kotbusta /kotbusta
-
-# Set ownership
-RUN chown -R kotbusta:kotbusta /kotbusta
-
-# Switch back to non-root user
 USER kotbusta
 
 # Run the application


### PR DESCRIPTION
## What changed

- limits self-hosted pull-request CI to branches inside `Heapy/kotbusta`
- routes PR verification to `kotbusta-ci` runners with read-only permissions
- combines the trusted main build and image publication into one job, removing artifact upload/download
- reuses the persistent `heapy-ci` multi-platform builder and boot-time QEMU registration
- moves base-image publishing to the same builder and removes the network GHA layer cache
- replaces the separate recursive `chown` layer with `COPY --chown`

## Why

The previous main pipeline took about 7m49s. Roughly two minutes were spent uploading and downloading the 207MB distribution, while each random Buildx builder downloaded the large amd64/arm64 base image again.

## Validation

- `actionlint`
- `git diff --check`
- clean `./kotlin test`: 178 Kotbusta tests plus 21 supporting tests passed
- `./kotlin "do" distTar -m kotbusta`
- distribution unpack and launcher validation
- `docker build --check .`
- persistent BuildKit smoke build verified amd64/arm64 and warm cache hits
